### PR TITLE
Integration tests in CI

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -1,4 +1,4 @@
-name: compile-integration-test
+name: integration-test
 
 on:
   workflow_call:
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    name: "make integration_tests"
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -20,11 +21,24 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-    name: "poetry run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
+    services:
+      elasticsearch:
+        image: elasticsearch:8.13.0
+        env:
+          discovery.type: single-node
+          xpack.license.self_generated.type: trial
+          xpack.security.enabled: false  # disable password and TLS; never do this in production!
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl --fail http://localhost:9200/_cluster/health"
+          --health-start-period 10s
+          --health-timeout 3s
+          --health-interval 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -34,24 +48,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ env.POETRY_VERSION }}
           working-directory: ${{ inputs.working-directory }}
-          cache-key: compile-integration
+          cache-key: integration-tests
 
-      - name: Install integration dependencies
+      - name: Install dependencies
         shell: bash
         run: poetry install --with=test_integration,test
 
-      - name: Check integration tests compile
+      - name: Run integration tests
         shell: bash
-        run: poetry run pytest -m compile tests/integration_tests
-
-      - name: Ensure the tests did not create any additional files
-        shell: bash
-        run: |
-          set -eu
-
-          STATUS="$(git status)"
-          echo "$STATUS"
-
-          # grep will exit non-zero if the target message isn't found,
-          # and `set -e` above will cause the step to fail.
-          echo "$STATUS" | grep 'nothing to commit, working tree clean'
+        run: make integration_test

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -59,20 +59,21 @@ jobs:
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
 
-  compile-integration-tests:
+  integration-test:
     name: cd ${{ matrix.working-directory }}
     needs: [ build ]
     if: ${{ needs.build.outputs.dirs-to-test != '[]' }}
     strategy:
       matrix:
         working-directory: ${{ fromJson(needs.build.outputs.dirs-to-test) }}
-    uses: ./.github/workflows/_compile_integration_test.yml
+    uses: ./.github/workflows/_integration_test.yml
     with:
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
+
   ci_success:
     name: "CI Success"
-    needs: [build, lint, test, compile-integration-tests]
+    needs: [build, lint, test, integration-test]
     if: |
       always()
     runs-on: ubuntu-latest

--- a/libs/elasticsearch/langchain_elasticsearch/_utilities.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_utilities.py
@@ -90,7 +90,7 @@ def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
         return similarity
 
 
-def check_if_model_deployed(client: Elasticsearch, model_id: str) -> None:
+def model_must_be_deployed(client: Elasticsearch, model_id: str) -> None:
     try:
         dummy = {"x": "y"}
         client.ml.infer_trained_model(model_id=model_id, docs=[dummy])
@@ -106,3 +106,11 @@ def check_if_model_deployed(client: Elasticsearch, model_id: str) -> None:
         # This error is expected because we do not know the expected document
         # shape and just use a dummy doc above.
         pass
+
+
+def model_is_deployed(es_client: Elasticsearch, model_id: str) -> bool:
+    try:
+        model_must_be_deployed(es_client, model_id)
+        return True
+    except NotFoundError:
+        return False

--- a/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
@@ -22,8 +22,8 @@ from langchain_core.vectorstores import VectorStore
 
 from langchain_elasticsearch._utilities import (
     DistanceStrategy,
-    check_if_model_deployed,
     maximal_marginal_relevance,
+    model_must_be_deployed,
     with_user_agent_header,
 )
 
@@ -204,7 +204,7 @@ class ApproxRetrievalStrategy(BaseRetrievalStrategy):
         self, client: "Elasticsearch", text_field: str, vector_query_field: str
     ) -> None:
         if self.query_model_id:
-            check_if_model_deployed(client, self.query_model_id)
+            model_must_be_deployed(client, self.query_model_id)
 
     def index(
         self,
@@ -348,7 +348,7 @@ class SparseRetrievalStrategy(BaseRetrievalStrategy):
         self, client: "Elasticsearch", text_field: str, vector_query_field: str
     ) -> None:
         if self.model_id:
-            check_if_model_deployed(client, self.model_id)
+            model_must_be_deployed(client, self.model_id)
 
             # Create a pipeline for the model
             client.ingest.put_pipeline(

--- a/libs/elasticsearch/pyproject.toml
+++ b/libs/elasticsearch/pyproject.toml
@@ -88,6 +88,5 @@ addopts = "--snapshot-warn-unused --strict-markers --strict-config --durations=5
 markers = [
   "requires: mark tests as requiring a specific library",
   "asyncio: mark tests as requiring asyncio",
-  "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"

--- a/libs/elasticsearch/tests/integration_tests/docker-compose.yml
+++ b/libs/elasticsearch/tests/integration_tests/docker-compose.yml
@@ -2,12 +2,11 @@ version: "3"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1 # https://www.docker.elastic.co/r/elasticsearch/elasticsearch
+    image: elasticsearch:8.13.0
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=false # security has been disabled, so no login or password is required.
-      - xpack.security.http.ssl.enabled=false
       - xpack.license.self_generated.type=trial
+      - xpack.security.enabled=false  # disable password and TLS; never do this in production!
     ports:
       - "9200:9200"
     healthcheck:
@@ -20,7 +19,7 @@ services:
       retries: 60
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.12.1
+    image: kibana:8.13.0
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
     ports:

--- a/libs/elasticsearch/tests/integration_tests/test_compile.py
+++ b/libs/elasticsearch/tests/integration_tests/test_compile.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-@pytest.mark.compile
-def test_placeholder() -> None:
-    """Used for compiling integration tests without running any real tests."""
-    pass


### PR DESCRIPTION
Run integration tests in CI.
- Remove check for OPENAI_API_KEY because this key is actually not required
- Create ES service in GitHub Action environment
- Check if a model is deployed in ES to determine if a test needs to be skipped
- Some refactoring for the previous point
- Remove obsolete compile test