### PR TITLE
Retriever: allow multiple indices with multiple content fields

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/retrievers.py
+++ b/libs/elasticsearch/langchain_elasticsearch/retrievers.py
@@ -62,7 +62,7 @@ class ElasticsearchRetriever(BaseRetriever):
     def from_es_params(
         index_name: Union[str, Sequence[str]],
         body_func: Callable[[str], Dict],
-        content_field: Optional[str] = None,
+        content_field: Optional[Union[str, Mapping[str, str]]] = None,
         document_mapper: Optional[Callable[[Mapping], Document]] = None,
         url: Optional[str] = None,
         cloud_id: Optional[str] = None,


### PR DESCRIPTION
Retriever can query multiple indices and map out the document content from different fields depending on the index.