### PR TITLE
fix: safely read metadata in default doc builder

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
@@ -889,7 +889,7 @@ class ElasticsearchStore(VectorStore):
         def default_doc_builder(hit: Dict) -> Document:
             return Document(
                 page_content=hit["_source"].get(self.query_field, ""),
-                metadata=hit["_source"]["metadata"],
+                metadata=hit["_source"].get("metadata", {}),
             )
 
         doc_builder = doc_builder or default_doc_builder


### PR DESCRIPTION
Updated the `default_doc_builder` function in _search to safely read the metadata field and default it to an empty object if it doesn't exist on the hit source document.

Closes #7 