### PR TITLE
Allow kwargs in body_func

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/retrievers.py
+++ b/libs/elasticsearch/langchain_elasticsearch/retrievers.py
@@ -129,18 +129,3 @@ class ElasticsearchRetriever(BaseRetriever):
         field = self.content_field[hit["_index"]]
         content = hit["_source"].pop(field)
         return Document(page_content=content, metadata=hit)
-
-    async def _aget_relevant_documents(
-        self,
-        query: str,
-        *,
-        run_manager: AsyncCallbackManagerForRetrieverRun,
-        **kwargs: Any,
-    ) -> Coroutine[Any, Any, List[Document]]:
-        return await run_in_executor(
-            None,
-            self._get_relevant_documents,
-            query,
-            **kwargs,
-            run_manager=run_manager.get_sync(),
-        )

--- a/libs/elasticsearch/langchain_elasticsearch/retrievers.py
+++ b/libs/elasticsearch/langchain_elasticsearch/retrievers.py
@@ -2,7 +2,6 @@ import logging
 from typing import (
     Any,
     Callable,
-    Coroutine,
     Dict,
     List,
     Mapping,
@@ -14,12 +13,10 @@ from typing import (
 
 from elasticsearch import Elasticsearch
 from langchain_core.callbacks import (
-    AsyncCallbackManagerForRetrieverRun,
     CallbackManagerForRetrieverRun,
 )
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
-from langchain_core.runnables.config import run_in_executor
 
 from langchain_elasticsearch._utilities import with_user_agent_header
 from langchain_elasticsearch.client import create_elasticsearch_client


### PR DESCRIPTION
Closes https://github.com/langchain-ai/langchain-elastic/issues/41

This PR enables the passing of auxiliary arguments when forming the `body` in a elastic search retrieval.

It seems to me that we need to override the `_aget_relevant_documents` because `langchain.core` does not pass `kwargs` to `_aget_relevant_documents` when it is called via `ainvoke`. It may be the case to open a PR in `langchain` instead, but for now I will leave it here.

I will add tests and try to fix the `mypy` errors if the approach is validated by the maintainers.