### PR TITLE
ElasticsearchStore async methods implementation

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/client.py
+++ b/libs/elasticsearch/langchain_elasticsearch/client.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict, Optional
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch
@@ -69,6 +70,6 @@ def create_elasticsearch_async_client(
 
     es_client = AsyncElasticsearch(**connection_params)
 
-    es_client.info()  # test connection
+    asyncio.run(es_client.info())  # test connection
 
     return es_client

--- a/libs/elasticsearch/langchain_elasticsearch/client.py
+++ b/libs/elasticsearch/langchain_elasticsearch/client.py
@@ -1,16 +1,16 @@
 from typing import Any, Dict, Optional
 
-from elasticsearch import Elasticsearch
+from elasticsearch import AsyncElasticsearch, Elasticsearch
 
 
-def create_elasticsearch_client(
+def _create_client_params(
     url: Optional[str] = None,
     cloud_id: Optional[str] = None,
     api_key: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
-) -> Elasticsearch:
+) -> Dict[str, Any]:
     if url and cloud_id:
         raise ValueError(
             "Both es_url and cloud_id are defined. Please provide only one."
@@ -33,7 +33,41 @@ def create_elasticsearch_client(
     if params is not None:
         connection_params.update(params)
 
+    return connection_params
+
+
+def create_elasticsearch_client(
+    url: Optional[str] = None,
+    cloud_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Elasticsearch:
+    connection_params = _create_client_params(
+        url, cloud_id, api_key, username, password, params
+    )
+
     es_client = Elasticsearch(**connection_params)
+
+    es_client.info()  # test connection
+
+    return es_client
+
+
+def create_elasticsearch_async_client(
+    url: Optional[str] = None,
+    cloud_id: Optional[str] = None,
+    api_key: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> AsyncElasticsearch:
+    connection_params = _create_client_params(
+        url, cloud_id, api_key, username, password, params
+    )
+
+    es_client = AsyncElasticsearch(**connection_params)
 
     es_client.info()  # test connection
 

--- a/libs/elasticsearch/langchain_elasticsearch/client.py
+++ b/libs/elasticsearch/langchain_elasticsearch/client.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Any, Dict, Optional
 
 from elasticsearch import AsyncElasticsearch, Elasticsearch
@@ -48,11 +47,8 @@ def create_elasticsearch_client(
     connection_params = _create_client_params(
         url, cloud_id, api_key, username, password, params
     )
-
     es_client = Elasticsearch(**connection_params)
-
     es_client.info()  # test connection
-
     return es_client
 
 
@@ -67,9 +63,6 @@ def create_elasticsearch_async_client(
     connection_params = _create_client_params(
         url, cloud_id, api_key, username, password, params
     )
-
     es_client = AsyncElasticsearch(**connection_params)
-
-    asyncio.run(es_client.info())  # test connection
-
+    # here we skip testing connection, assuming the sync client was created before
     return es_client

--- a/libs/elasticsearch/langchain_elasticsearch/client.py
+++ b/libs/elasticsearch/langchain_elasticsearch/client.py
@@ -65,4 +65,5 @@ def create_elasticsearch_async_client(
     )
     es_client = AsyncElasticsearch(**connection_params)
     # here we skip testing connection, assuming the sync client was created before
+    # so that we do not have to run an async method
     return es_client

--- a/libs/elasticsearch/langchain_elasticsearch/embeddings.py
+++ b/libs/elasticsearch/langchain_elasticsearch/embeddings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Optional
 
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers.vectorstore import EmbeddingService
+from elasticsearch.helpers.vectorstore import AsyncEmbeddingService, EmbeddingService
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import get_from_env
 
@@ -249,3 +249,45 @@ class EmbeddingServiceAdapter(EmbeddingService):
             List[float]: The embedding for the input query text.
         """
         return self._langchain_embeddings.embed_query(text)
+
+
+class AsyncEmbeddingServiceAdapter(AsyncEmbeddingService):
+    """
+    Adapter for LangChain Embeddings to support the AsyncEmbeddingService interface from
+    elasticsearch.helpers.vectorstore.
+    """
+
+    def __init__(self, langchain_embeddings: Embeddings):
+        self._langchain_embeddings = langchain_embeddings
+
+    def __eq__(self, other):  # type: ignore[no-untyped-def]
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        else:
+            return False
+
+    async def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """
+        Generate embeddings for a list of documents.
+
+        Args:
+            texts (List[str]): A list of document text strings to generate embeddings
+                for.
+
+        Returns:
+            List[List[float]]: A list of embeddings, one for each document in the input
+                list.
+        """
+        return await self._langchain_embeddings.aembed_documents(texts)
+
+    async def embed_query(self, text: str) -> List[float]:
+        """
+        Generate an embedding for a single query text.
+
+        Args:
+            text (str): The query text to generate an embedding for.
+
+        Returns:
+            List[float]: The embedding for the input query text.
+        """
+        return await self._langchain_embeddings.aembed_query(text)

--- a/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
@@ -851,7 +851,7 @@ class ElasticsearchStore(VectorStore):
         elif isinstance(strategy, RetrievalStrategy) and es_use_async:
             try:
                 async_strategy = _sync_to_async_strategy_map[type(strategy)](
-                    **vars(strategy)
+                    **{k: v for k, v in vars(strategy).items() if not k.startswith("_")}
                 )
             except KeyError:
                 raise TypeError(
@@ -860,7 +860,9 @@ class ElasticsearchStore(VectorStore):
                 )
         elif isinstance(strategy, AsyncRetrievalStrategy):
             try:
-                strategy = _async_to_sync_strategy_map[type(strategy)](**vars(strategy))
+                strategy = _async_to_sync_strategy_map[type(strategy)](
+                    **{k: v for k, v in vars(strategy).items() if not k.startswith("_")}
+                )
             except KeyError:
                 raise TypeError(
                     f"Cannot find a proper sync counterpart "

--- a/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
@@ -835,6 +835,12 @@ class ElasticsearchStore(VectorStore):
         ] = ApproxRetrievalStrategy(),
         es_params: Optional[Dict[str, Any]] = None,
     ):
+        if es_connection and es_use_async:
+            es_use_async = False
+            logger.warning(
+                "It is not possible to use Async IO if only an Elasticsearch"
+                " sync client is set, and not its async equivalent."
+            )
         if es_async_connection is not None:
             es_use_async = True
         async_strategy = None

--- a/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
@@ -301,6 +301,33 @@ class TestVectorStore:
         assert store._async_embedding_service is None
         assert isinstance(store._store.retrieval_strategy, BM25Strategy)
         assert store._store.retrieval_strategy.k1 == 20
+        store = ElasticsearchStore(
+            index_name="test_index",
+            es_connection=client,
+            es_async_connection=async_client,
+            strategy=DenseVectorStrategy(hybrid=True, rrf=True),
+        )
+        assert isinstance(
+            store._async_store.retrieval_strategy,  # type: ignore
+            AsyncDenseVectorStrategy,
+        )
+        assert store._async_store.retrieval_strategy.hybrid  # type: ignore
+        assert store._async_store.retrieval_strategy.rrf  # type: ignore
+        store = ElasticsearchStore(
+            index_name="test_index",
+            es_connection=client,
+            es_async_connection=async_client,
+            strategy=DenseVectorScriptScoreStrategy(
+                distance=DistanceMetric.DOT_PRODUCT
+            ),
+        )
+        assert isinstance(
+            store._async_store.retrieval_strategy,  # type: ignore
+            AsyncDenseVectorScriptScoreStrategy,
+        )
+        assert (
+            store._async_store.retrieval_strategy.distance == DistanceMetric.DOT_PRODUCT  # type: ignore
+        )
 
     def test_similarity_search(
         self, store: ElasticsearchStore, static_hits: List[Dict]

--- a/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
@@ -366,7 +366,6 @@ class TestVectorStore:
             custom_query=self.dummy_custom_query,
         )
 
-    @pytest.mark.asyncio
     async def test_asimilarity_search(
         self, store: ElasticsearchStore, static_hits: List[Dict]
     ) -> None:
@@ -424,7 +423,6 @@ class TestVectorStore:
             custom_query=self.dummy_custom_query,
         )
 
-    @pytest.mark.asyncio
     async def test_asimilarity_search_by_vector_with_relevance_scores(
         self, store: ElasticsearchStore, static_hits: List[Dict]
     ) -> None:
@@ -457,7 +455,6 @@ class TestVectorStore:
             refresh_indices=True,
         )
 
-    @pytest.mark.asyncio
     async def test_adelete(self, store: ElasticsearchStore) -> None:
         store._async_store.delete = AsyncMock(return_value=True)  # type: ignore
         actual = await store.adelete(
@@ -503,7 +500,6 @@ class TestVectorStore:
             bulk_kwargs={"x": "y"},
         )
 
-    @pytest.mark.asyncio
     async def test_aadd_texts(self, store: ElasticsearchStore) -> None:
         store._async_store.add_texts = AsyncMock(return_value=["10", "20"])  # type: ignore
         actual = await store.aadd_texts(
@@ -572,7 +568,6 @@ class TestVectorStore:
             bulk_kwargs={"x": "y"},
         )
 
-    @pytest.mark.asyncio
     async def test_aadd_embeddings(self, store: ElasticsearchStore) -> None:
         store._async_store.add_texts = AsyncMock(return_value=["10", "20"])  # type: ignore
         actual = await store.aadd_embeddings(
@@ -635,7 +630,6 @@ class TestVectorStore:
             custom_query=None,
         )
 
-    @pytest.mark.asyncio
     async def test_amax_marginal_relevance_search(
         self,
         hybrid_store: ElasticsearchStore,
@@ -675,7 +669,6 @@ class TestVectorStore:
         with pytest.raises(ValueError):
             hybrid_store.similarity_search_by_vector_with_relevance_scores([1, 2, 3])
 
-    @pytest.mark.asyncio
     async def test_aelasticsearch_hybrid_scores_guard(
         self, hybrid_store: ElasticsearchStore
     ) -> None:

--- a/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
@@ -6,6 +6,12 @@ from unittest.mock import Mock
 
 import pytest
 from elasticsearch import Elasticsearch
+from elasticsearch.helpers.vectorstore import (
+    AsyncBM25Strategy,
+    AsyncDenseVectorScriptScoreStrategy,
+    AsyncDenseVectorStrategy,
+    AsyncSparseVectorStrategy,
+)
 from langchain_core.documents import Document
 
 from langchain_elasticsearch.embeddings import Embeddings, EmbeddingServiceAdapter
@@ -155,35 +161,49 @@ class TestHitsToDocsScores:
 
 class TestConvertStrategy:
     def test_dense_approx(self) -> None:
-        actual = _convert_retrieval_strategy(
+        actual_sync, actual_async = _convert_retrieval_strategy(
             ApproxRetrievalStrategy(query_model_id="my model", hybrid=True, rrf=False),
             distance=DistanceStrategy.DOT_PRODUCT,
         )
-        assert isinstance(actual, DenseVectorStrategy)
-        assert actual.distance == DistanceMetric.DOT_PRODUCT
-        assert actual.model_id == "my model"
-        assert actual.hybrid is True
-        assert actual.rrf is False
+        assert isinstance(actual_sync, DenseVectorStrategy)
+        assert actual_sync.distance == DistanceMetric.DOT_PRODUCT
+        assert actual_sync.model_id == "my model"
+        assert actual_sync.hybrid is True
+        assert actual_sync.rrf is False
+        assert isinstance(actual_async, AsyncDenseVectorStrategy)
+        assert actual_async.distance == DistanceMetric.DOT_PRODUCT
+        assert actual_async.model_id == "my model"
+        assert actual_async.hybrid is True
+        assert actual_async.rrf is False
 
     def test_dense_exact(self) -> None:
-        actual = _convert_retrieval_strategy(
+        actual_sync, actual_async = _convert_retrieval_strategy(
             ExactRetrievalStrategy(), distance=DistanceStrategy.EUCLIDEAN_DISTANCE
         )
-        assert isinstance(actual, DenseVectorScriptScoreStrategy)
-        assert actual.distance == DistanceMetric.EUCLIDEAN_DISTANCE
+        assert isinstance(actual_sync, DenseVectorScriptScoreStrategy)
+        assert actual_sync.distance == DistanceMetric.EUCLIDEAN_DISTANCE
+        assert isinstance(actual_async, AsyncDenseVectorScriptScoreStrategy)
+        assert actual_async.distance == DistanceMetric.EUCLIDEAN_DISTANCE
 
     def test_sparse(self) -> None:
-        actual = _convert_retrieval_strategy(
+        actual_sync, actual_async = _convert_retrieval_strategy(
             SparseRetrievalStrategy(model_id="my model ID")
         )
-        assert isinstance(actual, SparseVectorStrategy)
-        assert actual.model_id == "my model ID"
+        assert isinstance(actual_sync, SparseVectorStrategy)
+        assert actual_sync.model_id == "my model ID"
+        assert isinstance(actual_async, AsyncSparseVectorStrategy)
+        assert actual_async.model_id == "my model ID"
 
     def test_bm25(self) -> None:
-        actual = _convert_retrieval_strategy(BM25RetrievalStrategy(k1=1.7, b=5.4))
-        assert isinstance(actual, BM25Strategy)
-        assert actual.k1 == 1.7
-        assert actual.b == 5.4
+        actual_sync, actual_async = _convert_retrieval_strategy(
+            BM25RetrievalStrategy(k1=1.7, b=5.4)
+        )
+        assert isinstance(actual_sync, BM25Strategy)
+        assert actual_sync.k1 == 1.7
+        assert actual_sync.b == 5.4
+        assert isinstance(actual_async, AsyncBM25Strategy)
+        assert actual_async.k1 == 1.7
+        assert actual_async.b == 5.4
 
 
 class TestVectorStore:

--- a/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/test_vectorstores.py
@@ -294,7 +294,7 @@ class TestVectorStore:
         store = ElasticsearchStore(
             index_name="test_index",
             es_connection=client,
-            es_use_async=True,
+            es_use_async_client=True,
             strategy=AsyncBM25Strategy(k1=20),
         )
         assert store._async_store is None
@@ -328,6 +328,11 @@ class TestVectorStore:
         assert (
             store._async_store.retrieval_strategy.distance == DistanceMetric.DOT_PRODUCT  # type: ignore
         )
+        with pytest.raises(ValueError):
+            ElasticsearchStore(
+                index_name="test_index",
+                es_async_connection=async_client,
+            )
 
     def test_similarity_search(
         self, store: ElasticsearchStore, static_hits: List[Dict]
@@ -669,7 +674,7 @@ class TestVectorStore:
         with pytest.raises(ValueError):
             hybrid_store.similarity_search_by_vector_with_relevance_scores([1, 2, 3])
 
-    async def test_aelasticsearch_hybrid_scores_guard(
+    async def test_elasticsearch_hybrid_scores_guard_async(
         self, hybrid_store: ElasticsearchStore
     ) -> None:
         """Ensure an error is raised when search with score in hybrid mode


### PR DESCRIPTION
The `ElasticsearchStore` class inherits the async methods implemented in `VectorStore`, that are actually not concurrent. The official Elasticsearch library now implements a helper for vector search, with both a sync and an async version, thanks to the developers of `langchain-elastic`!

The goal of this PR is to better integrate the helper in `ElasticsearchStore`, so that its async methods can be overridden with proper implementations.

I have considered different approaches, but there is critical difference in the design of the helper and the `VectorStore` class. The first has two completely independent classes for sync/async, the second exposes sync and async methods in the same abstraction. I am trying to follow the simplest approach possible, at the cost of:

-  Creating two Elasticsearch clients in `ElasticsearchStore`, even when only one of sync or async approach is used
-  Reducing the "availability" of the async methods, in order to make `ElasticsearchStore` robust on legacy code 

Hope to receive feedback and improvement hints