### PR TITLE
optional custom index settings in vectorstore

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -87,6 +87,12 @@ class AsyncElasticsearchStore(VectorStore):
             Name of the index to create.
         embedding: Embeddings
             Embedding function to use.
+        custom_index_settings: Optional[Dict[str, Any]]
+            A dictionary of custom settings for the index.
+            This can include configurations like the number of shards, number of replicas,
+            analysis settings, and other index-specific settings. If not provided, default
+            settings will be used. Note that if the same setting is provided by both the user
+            and the strategy, will raise an error.
 
     Key init args — client params:
         es_connection: Optional[Elasticsearch]
@@ -101,6 +107,8 @@ class AsyncElasticsearchStore(VectorStore):
             Password to use when connecting to Elasticsearch.
         es_api_key: Optional[str]
             API key to use when connecting to Elasticsearch.
+        es_params: Optional[Dict[str, Any]]
+            Additional parameters for the Elasticsearch client.
 
     Instantiate:
         .. code-block:: python
@@ -311,6 +319,7 @@ class AsyncElasticsearchStore(VectorStore):
             BaseRetrievalStrategy, AsyncRetrievalStrategy
         ] = ApproxRetrievalStrategy(),
         es_params: Optional[Dict[str, Any]] = None,
+        custom_index_settings: Optional[Dict[str, Any]] = None,
     ):
         if isinstance(strategy, BaseRetrievalStrategy):
             strategy = _convert_retrieval_strategy(
@@ -339,6 +348,7 @@ class AsyncElasticsearchStore(VectorStore):
             text_field=query_field,
             vector_field=vector_query_field,
             user_agent=user_agent("langchain-py-vs"),
+            custom_index_settings=custom_index_settings,
         )
 
         self.embedding = embedding

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -87,6 +87,12 @@ class ElasticsearchStore(VectorStore):
             Name of the index to create.
         embedding: Embeddings
             Embedding function to use.
+        custom_index_settings: Optional[Dict[str, Any]]
+            A dictionary of custom settings for the index.
+            This can include configurations like the number of shards, number of replicas,
+            analysis settings, and other index-specific settings. If not provided, default
+            settings will be used. Note that if the same setting is provided by both the user
+            and the strategy, will raise an error.
 
     Key init args — client params:
         es_connection: Optional[Elasticsearch]
@@ -101,6 +107,8 @@ class ElasticsearchStore(VectorStore):
             Password to use when connecting to Elasticsearch.
         es_api_key: Optional[str]
             API key to use when connecting to Elasticsearch.
+        es_params: Optional[Dict[str, Any]]
+            Additional parameters for the Elasticsearch client.
 
     Instantiate:
         .. code-block:: python
@@ -311,6 +319,7 @@ class ElasticsearchStore(VectorStore):
             BaseRetrievalStrategy, RetrievalStrategy
         ] = ApproxRetrievalStrategy(),
         es_params: Optional[Dict[str, Any]] = None,
+        custom_index_settings: Optional[Dict[str, Any]] = None,
     ):
         if isinstance(strategy, BaseRetrievalStrategy):
             strategy = _convert_retrieval_strategy(
@@ -339,6 +348,7 @@ class ElasticsearchStore(VectorStore):
             text_field=query_field,
             vector_field=vector_query_field,
             user_agent=user_agent("langchain-py-vs"),
+            custom_index_settings=custom_index_settings,
         )
 
         self.embedding = embedding


### PR DESCRIPTION
Hi, I have simply added a parameter to the ElasticsearchStore class in order to set default settings at index creation, that is made by the VectorStore helper in the Elasticsearch library. It is just arguments traversing calls, there is not much to test. There is also another minor fix in the doctring.

The main benefit of this parameter is to pre-configure the index when using the Elasticsearch vector store, which implicitly creates an index when first documents are added. One can, for example, set a correct number of replicas for his cluster, so that he has not to change it manually after creation, with all the waste of computational effort this implies