### PR TITLE
Ensure all public classes are picked up by documentation

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/cache.py
+++ b/libs/elasticsearch/langchain_elasticsearch/cache.py
@@ -12,9 +12,11 @@ from langchain_elasticsearch._async.cache import (
 from langchain_elasticsearch._async.cache import (
     AsyncElasticsearchEmbeddingsCache as _AsyncElasticsearchEmbeddingsCache,
 )
-from langchain_elasticsearch._sync.cache import (  # noqa: F401
-    ElasticsearchCache,
-    ElasticsearchEmbeddingsCache,
+from langchain_elasticsearch._sync.cache import (
+    ElasticsearchCache as _ElasticsearchCache,
+)
+from langchain_elasticsearch._sync.cache import (
+    ElasticsearchEmbeddingsCache as _ElasticsearchEmbeddingsCache,
 )
 from langchain_elasticsearch.client import (  # noqa: F401
     create_async_elasticsearch_client,
@@ -49,3 +51,12 @@ class AsyncElasticsearchEmbeddingsCache(_AsyncElasticsearchEmbeddingsCache):
 
     def yield_keys(self, *, prefix: Optional[str] = None) -> Iterator[str]:
         raise NotImplementedError("This class is asynchronous, use ayield_keys()")
+
+
+# these are only defined here so that they are picked up by Langchain's docs generator
+class ElasticsearchCache(_ElasticsearchCache):
+    pass
+
+
+class ElasticsearchEmbeddingsCache(_ElasticsearchEmbeddingsCache):
+    pass

--- a/libs/elasticsearch/langchain_elasticsearch/embeddings.py
+++ b/libs/elasticsearch/langchain_elasticsearch/embeddings.py
@@ -1,17 +1,24 @@
 from typing import List
 
+from langchain_core.embeddings import Embeddings  # noqa: F401
+
 from langchain_elasticsearch._async.embeddings import (
     AsyncElasticsearchEmbeddings as _AsyncElasticsearchEmbeddings,
 )
-from langchain_elasticsearch._async.embeddings import (  # noqa: F401
-    AsyncEmbeddingService,
-    AsyncEmbeddingServiceAdapter,
-    Embeddings,
+from langchain_elasticsearch._async.embeddings import (
+    AsyncEmbeddingService as _AsyncEmbeddingService,
 )
-from langchain_elasticsearch._sync.embeddings import (  # noqa: F401
-    ElasticsearchEmbeddings,
-    EmbeddingService,
-    EmbeddingServiceAdapter,
+from langchain_elasticsearch._async.embeddings import (
+    AsyncEmbeddingServiceAdapter as _AsyncEmbeddingServiceAdapter,
+)
+from langchain_elasticsearch._sync.embeddings import (
+    ElasticsearchEmbeddings as _ElasticsearchEmbeddings,
+)
+from langchain_elasticsearch._sync.embeddings import (
+    EmbeddingService as _EmbeddingService,
+)
+from langchain_elasticsearch._sync.embeddings import (
+    EmbeddingServiceAdapter as _EmbeddingServiceAdapter,
 )
 
 
@@ -23,3 +30,24 @@ class AsyncElasticsearchEmbeddings(_AsyncElasticsearchEmbeddings):
 
     def embed_query(self, text: str) -> List[float]:
         raise NotImplementedError("This class is asynchronous, use aembed_query()")
+
+
+# these are only defined here so that they are picked up by Langchain's docs generator
+class ElasticsearchEmbeddings(_ElasticsearchEmbeddings):
+    pass
+
+
+class EmbeddingService(_EmbeddingService):
+    pass
+
+
+class EmbeddingServiceAdapter(_EmbeddingServiceAdapter):
+    pass
+
+
+class AsyncEmbeddingService(_AsyncEmbeddingService):
+    pass
+
+
+class AsyncEmbeddingServiceAdapter(_AsyncEmbeddingServiceAdapter):
+    pass

--- a/libs/elasticsearch/langchain_elasticsearch/retrievers.py
+++ b/libs/elasticsearch/langchain_elasticsearch/retrievers.py
@@ -7,7 +7,7 @@ from langchain_elasticsearch._async.retrievers import (
     AsyncElasticsearchRetriever as _AsyncElasticsearchRetriever,
 )
 from langchain_elasticsearch._sync.retrievers import (
-    ElasticsearchRetriever,  # noqa: F401
+    ElasticsearchRetriever as _ElasticsearchRetriever,
 )
 
 
@@ -20,3 +20,8 @@ class AsyncElasticsearchRetriever(_AsyncElasticsearchRetriever):
         raise NotImplementedError(
             "This class is asynchronous, use _aget_relevant_documents()"
         )
+
+
+# this is only defined here so that it is picked up by Langchain's docs generator
+class ElasticsearchRetriever(_ElasticsearchRetriever):
+    pass

--- a/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/vectorstores.py
@@ -1,25 +1,45 @@
 from typing import Any, Optional
 
-from langchain_elasticsearch._async.vectorstores import (  # noqa: F401
-    AsyncBM25Strategy,
-    AsyncDenseVectorScriptScoreStrategy,
-    AsyncDenseVectorStrategy,
-    AsyncRetrievalStrategy,
-    AsyncSparseVectorStrategy,
-    DistanceMetric,
-    Document,
-    Embeddings,
+from langchain_elasticsearch._async.vectorstores import (
+    AsyncBM25Strategy as _AsyncBM25Strategy,
+)
+from langchain_elasticsearch._async.vectorstores import (
+    AsyncDenseVectorScriptScoreStrategy as _AsyncDenseVectorScriptScoreStrategy,
+)
+from langchain_elasticsearch._async.vectorstores import (
+    AsyncDenseVectorStrategy as _AsyncDenseVectorStrategy,
 )
 from langchain_elasticsearch._async.vectorstores import (
     AsyncElasticsearchStore as _AsyncElasticsearchStore,
 )
-from langchain_elasticsearch._sync.vectorstores import (  # noqa: F401
-    BM25Strategy,
-    DenseVectorScriptScoreStrategy,
-    DenseVectorStrategy,
-    ElasticsearchStore,
-    RetrievalStrategy,
-    SparseVectorStrategy,
+from langchain_elasticsearch._async.vectorstores import (
+    AsyncRetrievalStrategy as _AsyncRetrievalStrategy,
+)
+from langchain_elasticsearch._async.vectorstores import (
+    AsyncSparseVectorStrategy as _AsyncSparseVectorStrategy,
+)
+from langchain_elasticsearch._async.vectorstores import (
+    DistanceMetric,  # noqa: F401
+    Document,
+    Embeddings,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    BM25Strategy as _BM25Strategy,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    DenseVectorScriptScoreStrategy as _DenseVectorScriptScoreStrategy,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    DenseVectorStrategy as _DenseVectorStrategy,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    ElasticsearchStore as _ElasticsearchStore,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    RetrievalStrategy as _RetrievalStrategy,
+)
+from langchain_elasticsearch._sync.vectorstores import (
+    SparseVectorStrategy as _SparseVectorStrategy,
 )
 
 # deprecated strategy classes
@@ -54,3 +74,48 @@ class AsyncElasticsearchStore(_AsyncElasticsearchStore):
         raise NotImplementedError(
             "This class is asynchronous, use asimilarity_search()"
         )
+
+
+# these are only defined here so that they are picked up by Langchain's docs generator
+class ElasticsearchStore(_ElasticsearchStore):
+    pass
+
+
+class BM25Strategy(_BM25Strategy):
+    pass
+
+
+class DenseVectorScriptScoreStrategy(_DenseVectorScriptScoreStrategy):
+    pass
+
+
+class DenseVectorStrategy(_DenseVectorStrategy):
+    pass
+
+
+class RetrievalStrategy(_RetrievalStrategy):
+    pass
+
+
+class SparseVectorStrategy(_SparseVectorStrategy):
+    pass
+
+
+class AsyncBM25Strategy(_AsyncBM25Strategy):
+    pass
+
+
+class AsyncDenseVectorScriptScoreStrategy(_AsyncDenseVectorScriptScoreStrategy):
+    pass
+
+
+class AsyncDenseVectorStrategy(_AsyncDenseVectorStrategy):
+    pass
+
+
+class AsyncRetrievalStrategy(_AsyncRetrievalStrategy):
+    pass
+
+
+class AsyncSparseVectorStrategy(_AsyncSparseVectorStrategy):
+    pass

--- a/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
@@ -8,16 +8,18 @@ import pytest
 from elasticsearch import AsyncElasticsearch
 from langchain_core.documents import Document
 
-from langchain_elasticsearch._async.vectorstores import _convert_retrieval_strategy
-from langchain_elasticsearch._utilities import _hits_to_docs_scores
-from langchain_elasticsearch.embeddings import AsyncEmbeddingServiceAdapter, Embeddings
-from langchain_elasticsearch.vectorstores import (
+from langchain_elasticsearch._async.vectorstores import (
     ApproxRetrievalStrategy,
     AsyncBM25Strategy,
     AsyncDenseVectorScriptScoreStrategy,
     AsyncDenseVectorStrategy,
-    AsyncElasticsearchStore,
     AsyncSparseVectorStrategy,
+    _convert_retrieval_strategy,
+)
+from langchain_elasticsearch._utilities import _hits_to_docs_scores
+from langchain_elasticsearch.embeddings import AsyncEmbeddingServiceAdapter, Embeddings
+from langchain_elasticsearch.vectorstores import (
+    AsyncElasticsearchStore,
     BM25RetrievalStrategy,
     DistanceMetric,
     DistanceStrategy,

--- a/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
@@ -8,21 +8,23 @@ import pytest
 from elasticsearch import Elasticsearch
 from langchain_core.documents import Document
 
-from langchain_elasticsearch._sync.vectorstores import _convert_retrieval_strategy
-from langchain_elasticsearch._utilities import _hits_to_docs_scores
-from langchain_elasticsearch.embeddings import Embeddings, EmbeddingServiceAdapter
-from langchain_elasticsearch.vectorstores import (
+from langchain_elasticsearch._sync.vectorstores import (
     ApproxRetrievalStrategy,
-    BM25RetrievalStrategy,
     BM25Strategy,
     DenseVectorScriptScoreStrategy,
     DenseVectorStrategy,
+    SparseVectorStrategy,
+    _convert_retrieval_strategy,
+)
+from langchain_elasticsearch._utilities import _hits_to_docs_scores
+from langchain_elasticsearch.embeddings import Embeddings, EmbeddingServiceAdapter
+from langchain_elasticsearch.vectorstores import (
+    BM25RetrievalStrategy,
     DistanceMetric,
     DistanceStrategy,
     ElasticsearchStore,
     ExactRetrievalStrategy,
     SparseRetrievalStrategy,
-    SparseVectorStrategy,
 )
 
 from ...fake_embeddings import ConsistentFakeEmbeddings


### PR DESCRIPTION
Due to the way Langchain generate documentation, classes that are defined in `_sync` and `_async` modules are not getting included in the docs. This fix creates proxy classes in the top-level modules for all these classes so that they are added to the documentation.