### PR TITLE
Elastisearch 'fields' parameter not usable in similarity_search* methods

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -389,6 +389,7 @@ class AsyncElasticsearchStore(VectorStore):
         k: int = 4,
         fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
+            fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -413,6 +414,7 @@ class AsyncElasticsearchStore(VectorStore):
             k=k,
             num_candidates=fetch_k,
             filter=filter,
+            fields=fields,
             custom_query=custom_query,
         )
         docs = _hits_to_docs_scores(
@@ -504,7 +506,8 @@ class AsyncElasticsearchStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[List[dict]] = None,
-        *,
+        fields: Optional[List[str]] = None,
+            *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
         ] = None,
@@ -528,7 +531,11 @@ class AsyncElasticsearchStore(VectorStore):
             raise ValueError("scores are currently not supported in hybrid mode")
 
         hits = await self._store.search(
-            query=query, k=k, filter=filter, custom_query=custom_query
+            query=query,
+            k=k,
+            filter=filter,
+            fields=fields,
+            custom_query=custom_query
         )
         return _hits_to_docs_scores(
             hits=hits,
@@ -541,7 +548,8 @@ class AsyncElasticsearchStore(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[List[Dict]] = None,
-        *,
+        fields: Optional[List[str]] = None,
+            *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
         ] = None,
@@ -569,6 +577,7 @@ class AsyncElasticsearchStore(VectorStore):
             query_vector=embedding,
             k=k,
             filter=filter,
+            fields=fields,
             custom_query=custom_query,
         )
         return _hits_to_docs_scores(

--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -389,7 +389,7 @@ class AsyncElasticsearchStore(VectorStore):
         k: int = 4,
         fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
-            fields: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]

--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -420,6 +420,7 @@ class AsyncElasticsearchStore(VectorStore):
         docs = _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
         return [doc for doc, _score in docs]
@@ -540,6 +541,7 @@ class AsyncElasticsearchStore(VectorStore):
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 
@@ -583,6 +585,7 @@ class AsyncElasticsearchStore(VectorStore):
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -389,6 +389,7 @@ class ElasticsearchStore(VectorStore):
         k: int = 4,
         fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -413,6 +414,7 @@ class ElasticsearchStore(VectorStore):
             k=k,
             num_candidates=fetch_k,
             filter=filter,
+            fields=fields,
             custom_query=custom_query,
         )
         docs = _hits_to_docs_scores(
@@ -504,6 +506,7 @@ class ElasticsearchStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -528,7 +531,11 @@ class ElasticsearchStore(VectorStore):
             raise ValueError("scores are currently not supported in hybrid mode")
 
         hits = self._store.search(
-            query=query, k=k, filter=filter, custom_query=custom_query
+            query=query,
+            k=k,
+            filter=filter,
+            fields=fields,
+            custom_query=custom_query
         )
         return _hits_to_docs_scores(
             hits=hits,
@@ -541,6 +548,7 @@ class ElasticsearchStore(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[List[Dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -569,6 +577,7 @@ class ElasticsearchStore(VectorStore):
             query_vector=embedding,
             k=k,
             filter=filter,
+            fields=fields,
             custom_query=custom_query,
         )
         return _hits_to_docs_scores(

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -420,6 +420,7 @@ class ElasticsearchStore(VectorStore):
         docs = _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
         return [doc for doc, _score in docs]
@@ -540,6 +541,7 @@ class ElasticsearchStore(VectorStore):
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 
@@ -583,6 +585,7 @@ class ElasticsearchStore(VectorStore):
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 

--- a/libs/elasticsearch/langchain_elasticsearch/_utilities.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_utilities.py
@@ -69,11 +69,14 @@ def _hits_to_docs_scores(
 
     documents = []
 
-    def default_doc_builder(hit: Dict) -> Document:
-        return Document(
+    def default_doc_builder(hit: Dict, fields: List[str]) -> Document:
+        doc = Document(
             page_content=hit["_source"].get(content_field, ""),
             metadata=hit["_source"].get("metadata", {}),
         )
+        for field_key in fields:
+            doc.metadata[field_key] = hit["_source"].get(field_key, None)
+        return doc
 
     doc_builder = doc_builder or default_doc_builder
 
@@ -87,7 +90,7 @@ def _hits_to_docs_scores(
             ]:
                 hit["_source"]["metadata"][field] = hit["_source"][field]
 
-        doc = doc_builder(hit)
+        doc = doc_builder(hit, fields)
         documents.append((doc, hit["_score"]))
 
     return documents


### PR DESCRIPTION
See Issue #62 for the description for this PR.