### PR TITLE
Allow `fields` to be passed in to all similarity searches

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -389,6 +389,7 @@ class AsyncElasticsearchStore(VectorStore):
         k: int = 4,
         fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -414,11 +415,13 @@ class AsyncElasticsearchStore(VectorStore):
             num_candidates=fetch_k,
             filter=filter,
             custom_query=custom_query,
+            fields=fields,
         )
         docs = _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
             doc_builder=doc_builder,
+            fields=fields,
         )
         return [doc for doc, _score in docs]
 
@@ -504,6 +507,7 @@ class AsyncElasticsearchStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -528,12 +532,13 @@ class AsyncElasticsearchStore(VectorStore):
             raise ValueError("scores are currently not supported in hybrid mode")
 
         hits = await self._store.search(
-            query=query, k=k, filter=filter, custom_query=custom_query
+            query=query, k=k, filter=filter, custom_query=custom_query, fields=fields
         )
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
             doc_builder=doc_builder,
+            fields=fields,
         )
 
     async def asimilarity_search_by_vector_with_relevance_scores(
@@ -541,6 +546,7 @@ class AsyncElasticsearchStore(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[List[Dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -570,10 +576,12 @@ class AsyncElasticsearchStore(VectorStore):
             k=k,
             filter=filter,
             custom_query=custom_query,
+            fields=fields,
         )
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -389,6 +389,7 @@ class ElasticsearchStore(VectorStore):
         k: int = 4,
         fetch_k: int = 50,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -412,12 +413,14 @@ class ElasticsearchStore(VectorStore):
             query=query,
             k=k,
             num_candidates=fetch_k,
+            fields=fields,
             filter=filter,
             custom_query=custom_query,
         )
         docs = _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
         return [doc for doc, _score in docs]
@@ -504,6 +507,7 @@ class ElasticsearchStore(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[List[dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -528,11 +532,12 @@ class ElasticsearchStore(VectorStore):
             raise ValueError("scores are currently not supported in hybrid mode")
 
         hits = self._store.search(
-            query=query, k=k, filter=filter, custom_query=custom_query
+            query=query, k=k, filter=filter, custom_query=custom_query, fields=fields
         )
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 
@@ -541,6 +546,7 @@ class ElasticsearchStore(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[List[Dict]] = None,
+        fields: Optional[List[str]] = None,
         *,
         custom_query: Optional[
             Callable[[Dict[str, Any], Optional[str]], Dict[str, Any]]
@@ -570,10 +576,12 @@ class ElasticsearchStore(VectorStore):
             k=k,
             filter=filter,
             custom_query=custom_query,
+            fields=fields,
         )
         return _hits_to_docs_scores(
             hits=hits,
             content_field=self.query_field,
+            fields=fields,
             doc_builder=doc_builder,
         )
 


### PR DESCRIPTION
Adds support for passing in a list of fields to be pulled out as metadata in each similarity search method in the `ElasticVectorStore` classes, as is currently implemented in the `max_marginal_relevance_search` methods

See #62 #64 