### PR TITLE
feat: add id prop handling to default doc builder

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/_utilities.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_utilities.py
@@ -71,6 +71,7 @@ def _hits_to_docs_scores(
 
     def default_doc_builder(hit: Dict) -> Document:
         return Document(
+            id=hit["_id"],
             page_content=hit["_source"].get(content_field, ""),
             metadata=hit["_source"].get("metadata", {}),
         )


### PR DESCRIPTION
## ✨ Proposal

This PR adds support for the `id` property in the `default_doc_builder`. Although optional, the `id` is a highly relevant field for many use cases, including unique document identification, tracking, and integration with external systems.

## ✅ Expected Behavior

- If an `id` is retrieved, it will be used by the `default_doc_builder`.
- If the `id` is absent **at the time of index creation**, the behavior remains unchanged — the system will continue to function exactly as it did before.

## 🛠️ Motivation

Supporting a pre-filled `id` reduces the need for custom logic elsewhere in the application and enables more consistent document handling when a specific identifier is required.

## 🔄 Compatibility

This is a **non-breaking change**. The `id` remains optional, ensuring full backward compatibility with existing implementations.
