### PR TITLE
Update testing suite 

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -34,7 +34,7 @@ jobs:
           - "3.12"
           - "3.13"
         elasticsearch-version:
-          - "8.13.0"
+          - "8.15.0"
           - "8.19.0"
           - "9.1.2"
     services:

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -30,6 +30,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     services:
       elasticsearch:
         image: elasticsearch:8.13.0

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -32,9 +32,13 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+        elasticsearch-version:
+          - "8.13.0"
+          - "8.19.0"
+          - "9.1.2"
     services:
       elasticsearch:
-        image: elasticsearch:8.13.0
+        image: elasticsearch:${{ matrix.elasticsearch-version }}
         env:
           discovery.type: single-node
           xpack.license.self_generated.type: trial

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -25,6 +25,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.9"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -29,8 +29,8 @@ jobs:
         # Starting new jobs is also relatively slow,
         # so linting on fewer versions makes CI faster.
         python-version:
-          - "3.8"
-          - "3.11"
+          - "3.9"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -20,10 +20,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     name: "make test #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,6 +18,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.9"

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -1,7 +1,7 @@
 """Fake Embedding class for testing purposes."""
 
-from typing import List
 import hashlib
+from typing import List
 
 from langchain_core.embeddings import Embeddings
 

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -50,7 +50,20 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
         return (await self.aembed_documents([text]))[0]
     
 class AsyncStableHashEmbeddings(Embeddings):
-    """Embeddings which return stable hash-based vectors for the same texts."""
+    """Deterministic hash-based embeddings for robust testing. (async version)
+
+    Why:
+    - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
+      Quantization (int8) + HNSW ANN can slightly disturb scores/ranking
+      especially when vectors are nearly identical (e.g., 9 ones + tiny delta).
+    - Tests need deterministic separation so small quantization/ANN
+      effects do not flip top-1 results or break strict assertions.
+
+    What:
+    - Produce a 10-dim vector from md5(text), take first 10 bytes, convert to
+      integers, then L1-normalize so values sum to 1.0. This gives stable,
+      well-separated but deterministic vectors which will work across ES versions.
+    """
 
     @staticmethod
     def _encode(text: str) -> List[float]:

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -13,7 +13,7 @@ class AsyncFakeEmbeddings(Embeddings):
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings.
         Embeddings encode each text as its index."""
-        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
+        return [[float(1.0)] * 9 + [float(i * 2)] for i in range(len(texts))]
 
     async def aembed_query(self, text: str) -> List[float]:
         """Return constant query embeddings.

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -56,7 +56,7 @@ class AsyncStableHashEmbeddings(Embeddings):
     Why:
     - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
       Quantization (int8) + HNSW ANN can slightly disturb scores/ranking
-      especially when vectors are nearly identical (e.g., 9 ones + tiny delta).
+      especially when vectors are nearly identical.
     - Tests need deterministic separation so small quantization/ANN
       effects do not flip top-1 results or break strict assertions.
 

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -48,7 +48,8 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
         """Return consistent embeddings for the text, if seen before, or a constant
         one if the text is unknown."""
         return (await self.aembed_documents([text]))[0]
-    
+
+
 class AsyncStableHashEmbeddings(Embeddings):
     """Deterministic hash-based embeddings for robust testing. (async version)
 
@@ -70,7 +71,7 @@ class AsyncStableHashEmbeddings(Embeddings):
         digest = hashlib.md5(text.encode("utf-8")).digest()
         raw = [b for b in digest[:10]]
         total = sum(raw)
-        return [float(v)/float(total) for v in raw]
+        return [float(v) / float(total) for v in raw]
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return stable hash-based embeddings for each text."""

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -25,32 +25,6 @@ class AsyncFakeEmbeddings(Embeddings):
 
 
 class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
-    """Fake embeddings which remember all the texts seen so far to return consistent
-    vectors for the same texts."""
-
-    def __init__(self, dimensionality: int = 10) -> None:
-        self.known_texts: List[str] = []
-        self.dimensionality = dimensionality
-
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
-        """Return consistent embeddings for each text seen so far."""
-        out_vectors = []
-        for text in texts:
-            if text not in self.known_texts:
-                self.known_texts.append(text)
-            vector = [float(1.0)] * (self.dimensionality - 1) + [
-                float(self.known_texts.index(text))
-            ]
-            out_vectors.append(vector)
-        return out_vectors
-
-    async def aembed_query(self, text: str) -> List[float]:
-        """Return consistent embeddings for the text, if seen before, or a constant
-        one if the text is unknown."""
-        return (await self.aembed_documents([text]))[0]
-
-
-class AsyncStableHashEmbeddings(Embeddings):
     """Deterministic hash-based embeddings for robust testing. (async version)
 
     Why:

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -25,7 +25,7 @@ class AsyncFakeEmbeddings(Embeddings):
 
 
 class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
-    """Deterministic hash-based embeddings for robust testing. (async version)
+    """Deterministic hash-based embeddings for robust testing (async version).
 
     Why:
     - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
@@ -35,7 +35,7 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize
+    - Produce a 16-dim vector from md5(text), convert to floats, then L1-normalize
       so values sum to 1.0. Round to 2 decimal places for precision stability.
       This gives stable, well-separated but deterministic vectors which will work
       across ES versions.

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -35,9 +35,9 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize 
+    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize
       so values sum to 1.0. Round to 2 decimal places for precision stability.
-      This gives stable, well-separated but deterministic vectors which will work 
+      This gives stable, well-separated but deterministic vectors which will work
       across ES versions.
     """
 

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -1,6 +1,7 @@
 """Fake Embedding class for testing purposes."""
 
 from typing import List
+import hashlib
 
 from langchain_core.embeddings import Embeddings
 
@@ -13,7 +14,7 @@ class AsyncFakeEmbeddings(Embeddings):
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings.
         Embeddings encode each text as its index."""
-        return [[float(1.0)] * 9 + [float(i * 2)] for i in range(len(texts))]
+        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
 
     async def aembed_query(self, text: str) -> List[float]:
         """Return constant query embeddings.
@@ -47,3 +48,21 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
         """Return consistent embeddings for the text, if seen before, or a constant
         one if the text is unknown."""
         return (await self.aembed_documents([text]))[0]
+    
+class AsyncStableHashEmbeddings(Embeddings):
+    """Embeddings which return stable hash-based vectors for the same texts."""
+
+    @staticmethod
+    def _encode(text: str) -> List[float]:
+        digest = hashlib.md5(text.encode("utf-8")).digest()
+        raw = [b for b in digest[:10]]
+        total = sum(raw)
+        return [float(v)/float(total) for v in raw]
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Return stable hash-based embeddings for each text."""
+        return [self._encode(text) for text in texts]
+
+    async def aembed_query(self, text: str) -> List[float]:
+        """Return stable hash-based embeddings for the text."""
+        return self._encode(text)

--- a/libs/elasticsearch/tests/_async/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_async/fake_embeddings.py
@@ -35,17 +35,18 @@ class AsyncConsistentFakeEmbeddings(AsyncFakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 10-dim vector from md5(text), take first 10 bytes, convert to
-      integers, then L1-normalize so values sum to 1.0. This gives stable,
-      well-separated but deterministic vectors which will work across ES versions.
+    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize 
+      so values sum to 1.0. Round to 2 decimal places for precision stability.
+      This gives stable, well-separated but deterministic vectors which will work 
+      across ES versions.
     """
 
     @staticmethod
     def _encode(text: str) -> List[float]:
         digest = hashlib.md5(text.encode("utf-8")).digest()
-        raw = [b for b in digest[:10]]
-        total = sum(raw)
-        return [float(v) / float(total) for v in raw]
+        total = sum(digest)
+        # Round to 2 decimal places to avoid precision issues
+        return [round(float(v) / float(total), 2) for v in digest]
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return stable hash-based embeddings for each text."""

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -1,7 +1,7 @@
 """Fake Embedding class for testing purposes."""
 
-from typing import List
 import hashlib
+from typing import List
 
 from langchain_core.embeddings import Embeddings
 

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -75,8 +75,8 @@ class StableHashEmbeddings(Embeddings):
         total = sum(raw)
         return [float(v) / float(total) for v in raw]
 
-    def embed_documents(self, texts):
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
         return [self._encode(text) for text in texts]
 
-    def embed_query(self, text):
+    def embed_query(self, text: str) -> List[float]:
         return self._encode(text)

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -37,17 +37,18 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 10-dim vector from md5(text), take first 10 bytes, convert to
-      integers, then L1-normalize so values sum to 1.0. This gives stable,
-      well-separated but deterministic vectors which will work across ES versions.
+    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize 
+      so values sum to 1.0. Round to 2 decimal places for precision stability.
+      This gives stable, well-separated but deterministic vectors which will work 
+      across ES versions.
     """
 
     @staticmethod
     def _encode(text: str) -> List[float]:
         digest = hashlib.md5(text.encode("utf-8")).digest()
-        raw = [b for b in digest[:10]]
-        total = sum(raw)
-        return [float(v) / float(total) for v in raw]
+        total = sum(digest)
+        # Round to 2 decimal places to avoid precision issues
+        return [round(float(v) / float(total), 2) for v in digest]
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         return [self._encode(text) for text in texts]

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -25,7 +25,7 @@ class FakeEmbeddings(Embeddings):
 
 
 class ConsistentFakeEmbeddings(FakeEmbeddings):
-    """Deterministic hash-based embeddings for robust testing. (async version)
+    """Deterministic hash-based embeddings for robust testing (sync version).
 
     Why:
     - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
@@ -35,7 +35,7 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize
+    - Produce a 16-dim vector from md5(text), convert to floats, then L1-normalize
       so values sum to 1.0. Round to 2 decimal places for precision stability.
       This gives stable, well-separated but deterministic vectors which will work
       across ES versions.

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -58,7 +58,7 @@ class StableHashEmbeddings(Embeddings):
     Why:
     - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
       Quantization (int8) + HNSW ANN can slightly disturb scores/ranking
-      especially when vectors are nearly identical (e.g., 9 ones + tiny delta).
+      especially when vectors are nearly identical.
     - Tests need deterministic separation so small quantization/ANN
       effects do not flip top-1 results or break strict assertions.
 

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -14,9 +14,7 @@ class FakeEmbeddings(Embeddings):
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings.
         Embeddings encode each text as its index."""
-        temp = [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
-        print(temp)
-        return temp
+        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
 
     def embed_query(self, text: str) -> List[float]:
         """Return constant query embeddings.
@@ -27,7 +25,7 @@ class FakeEmbeddings(Embeddings):
 
 
 class ConsistentFakeEmbeddings(FakeEmbeddings):
-    """Deterministic hash-based embeddings for robust testing. (sync version)
+    """Deterministic hash-based embeddings for robust testing. (async version)
 
     Why:
     - Elasticsearch 8.14+ indexes dense vectors with int8_hnsw by default.
@@ -37,9 +35,9 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
       effects do not flip top-1 results or break strict assertions.
 
     What:
-    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize 
+    - Produce a 16-dim vector from md5(text), convert to integers, then L1-normalize
       so values sum to 1.0. Round to 2 decimal places for precision stability.
-      This gives stable, well-separated but deterministic vectors which will work 
+      This gives stable, well-separated but deterministic vectors which will work
       across ES versions.
     """
 
@@ -51,7 +49,9 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
         return [round(float(v) / float(total), 2) for v in digest]
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Return stable hash-based embeddings for each text."""
         return [self._encode(text) for text in texts]
 
     def embed_query(self, text: str) -> List[float]:
+        """Return stable hash-based embeddings for the text."""
         return self._encode(text)

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -27,32 +27,6 @@ class FakeEmbeddings(Embeddings):
 
 
 class ConsistentFakeEmbeddings(FakeEmbeddings):
-    """Fake embeddings which remember all the texts seen so far to return consistent
-    vectors for the same texts."""
-
-    def __init__(self, dimensionality: int = 10) -> None:
-        self.known_texts: List[str] = []
-        self.dimensionality = dimensionality
-
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        """Return consistent embeddings for each text seen so far."""
-        out_vectors = []
-        for text in texts:
-            if text not in self.known_texts:
-                self.known_texts.append(text)
-            vector = [float(1.0)] * (self.dimensionality - 1) + [
-                float(self.known_texts.index(text))
-            ]
-            out_vectors.append(vector)
-        return out_vectors
-
-    def embed_query(self, text: str) -> List[float]:
-        """Return consistent embeddings for the text, if seen before, or a constant
-        one if the text is unknown."""
-        return (self.embed_documents([text]))[0]
-
-
-class StableHashEmbeddings(Embeddings):
     """Deterministic hash-based embeddings for robust testing. (sync version)
 
     Why:

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -13,7 +13,9 @@ class FakeEmbeddings(Embeddings):
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         """Return simple embeddings.
         Embeddings encode each text as its index."""
-        return [[float(1.0)] * 9 + [float(i)] for i in range(len(texts))]
+        temp = [[float(1.0)] * 9 + [float(i * 2)] for i in range(len(texts))]
+        print(temp)
+        return temp
 
     def embed_query(self, text: str) -> List[float]:
         """Return constant query embeddings.

--- a/libs/elasticsearch/tests/_sync/fake_embeddings.py
+++ b/libs/elasticsearch/tests/_sync/fake_embeddings.py
@@ -50,7 +50,8 @@ class ConsistentFakeEmbeddings(FakeEmbeddings):
         """Return consistent embeddings for the text, if seen before, or a constant
         one if the text is unknown."""
         return (self.embed_documents([text]))[0]
-    
+
+
 class StableHashEmbeddings(Embeddings):
     """Deterministic hash-based embeddings for robust testing. (sync version)
 
@@ -72,11 +73,10 @@ class StableHashEmbeddings(Embeddings):
         digest = hashlib.md5(text.encode("utf-8")).digest()
         raw = [b for b in digest[:10]]
         total = sum(raw)
-        return [float(v)/float(total) for v in raw]
-    
+        return [float(v) / float(total) for v in raw]
+
     def embed_documents(self, texts):
         return [self._encode(text) for text in texts]
-    
+
     def embed_query(self, text):
         return self._encode(text)
-    

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -4,11 +4,14 @@ from typing import List
 
 from ._async.fake_embeddings import (
     AsyncConsistentFakeEmbeddings as _AsyncConsistentFakeEmbeddings,
+    AsyncStableHashEmbeddings as _AsyncStableHashEmbeddings,
+    AsyncFakeEmbeddings as _AsyncFakeEmbeddings,
 )
-from ._async.fake_embeddings import AsyncFakeEmbeddings as _AsyncFakeEmbeddings
+
 from ._sync.fake_embeddings import (  # noqa: F401
     ConsistentFakeEmbeddings,
     FakeEmbeddings,
+    StableHashEmbeddings
 )
 
 
@@ -23,6 +26,13 @@ class AsyncFakeEmbeddings(_AsyncFakeEmbeddings):
 
 
 class AsyncConsistentFakeEmbeddings(_AsyncConsistentFakeEmbeddings):
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        raise NotImplementedError("This class is asynchronous, use aembed_documents()")
+
+    def embed_query(self, text: str) -> List[float]:
+        raise NotImplementedError("This class is asynchronous, use aembed_query()")
+    
+class AsyncStableHashEmbeddings(_AsyncStableHashEmbeddings):
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         raise NotImplementedError("This class is asynchronous, use aembed_documents()")
 

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -30,4 +30,3 @@ class AsyncConsistentFakeEmbeddings(_AsyncConsistentFakeEmbeddings):
 
     def embed_query(self, text: str) -> List[float]:
         raise NotImplementedError("This class is asynchronous, use aembed_query()")
-

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -34,7 +34,8 @@ class AsyncConsistentFakeEmbeddings(_AsyncConsistentFakeEmbeddings):
 
     def embed_query(self, text: str) -> List[float]:
         raise NotImplementedError("This class is asynchronous, use aembed_query()")
-    
+
+
 class AsyncStableHashEmbeddings(_AsyncStableHashEmbeddings):
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
         raise NotImplementedError("This class is asynchronous, use aembed_documents()")

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -8,7 +8,6 @@ from ._async.fake_embeddings import (
 from ._async.fake_embeddings import (
     AsyncFakeEmbeddings as _AsyncFakeEmbeddings,
 )
-
 from ._sync.fake_embeddings import (  # noqa: F401
     ConsistentFakeEmbeddings,
     FakeEmbeddings,

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -4,14 +4,17 @@ from typing import List
 
 from ._async.fake_embeddings import (
     AsyncConsistentFakeEmbeddings as _AsyncConsistentFakeEmbeddings,
-    AsyncStableHashEmbeddings as _AsyncStableHashEmbeddings,
+)
+from ._async.fake_embeddings import (
     AsyncFakeEmbeddings as _AsyncFakeEmbeddings,
 )
-
+from ._async.fake_embeddings import (
+    AsyncStableHashEmbeddings as _AsyncStableHashEmbeddings,
+)
 from ._sync.fake_embeddings import (  # noqa: F401
     ConsistentFakeEmbeddings,
     FakeEmbeddings,
-    StableHashEmbeddings
+    StableHashEmbeddings,
 )
 
 

--- a/libs/elasticsearch/tests/fake_embeddings.py
+++ b/libs/elasticsearch/tests/fake_embeddings.py
@@ -8,13 +8,10 @@ from ._async.fake_embeddings import (
 from ._async.fake_embeddings import (
     AsyncFakeEmbeddings as _AsyncFakeEmbeddings,
 )
-from ._async.fake_embeddings import (
-    AsyncStableHashEmbeddings as _AsyncStableHashEmbeddings,
-)
+
 from ._sync.fake_embeddings import (  # noqa: F401
     ConsistentFakeEmbeddings,
     FakeEmbeddings,
-    StableHashEmbeddings,
 )
 
 
@@ -35,10 +32,3 @@ class AsyncConsistentFakeEmbeddings(_AsyncConsistentFakeEmbeddings):
     def embed_query(self, text: str) -> List[float]:
         raise NotImplementedError("This class is asynchronous, use aembed_query()")
 
-
-class AsyncStableHashEmbeddings(_AsyncStableHashEmbeddings):
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        raise NotImplementedError("This class is asynchronous, use aembed_documents()")
-
-    def embed_query(self, text: str) -> List[float]:
-        raise NotImplementedError("This class is asynchronous, use aembed_query()")

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -573,7 +573,7 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and search with metadata."""
         texts = ["foo", "bar", "baz"]
-        embeddings = AsyncConsistentFakeEmbeddings()
+        embeddings = AsyncStableHashEmbeddings()
         docsearch = await AsyncElasticsearchStore.afrom_texts(
             texts,
             embedding=embeddings,

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -177,8 +177,7 @@ class TestElasticsearch:
             assert knn["num_candidates"] == 50
             assert knn["filter"] == []
             assert (
-                isinstance(knn["query_vector"], list) 
-                and len(knn["query_vector"]) == 10
+                isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
             )
             return query_body
 
@@ -614,8 +613,7 @@ class TestElasticsearch:
         else:
             # Prev versions don't use int8_hnsw quantization default
             # We expect an exact match on score for older versions
-            assert score == 1.0 
-
+            assert score == 1.0
 
     @pytest.mark.asyncio
     async def test_similarity_search_approx_with_hybrid_search_rrf(
@@ -624,20 +622,20 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
-        #Check version of ES
-        #ES 8.15+ requires rank_window_size instead of window_size
+        # Check version of ES
+        # ES 8.15+ requires rank_window_size instead of window_size
         _es = create_es_client(es_params)
         try:
             _info = await _es.info()
             _version = _info["version"]["number"]
             _major, _minor = map(int, _version.split(".")[:2])
-            if ( _major, _minor) >= (8, 15):
-                window_key = "rank_window_size"    
+            if (_major, _minor) >= (8, 15):
+                window_key = "rank_window_size"
             else:
                 window_key = "window_size"
         finally:
             await _es.close()
-            
+
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
@@ -826,7 +824,7 @@ class TestElasticsearch:
         )
         doc, score = output[0]
         assert doc == Document(page_content="foo", metadata={"page": "0"})
-        #Use the client to pick a tolernace for based on ES version
+        # Use the client to pick a tolernace for based on ES version
         info = await docsearch.client.info()
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
@@ -837,7 +835,7 @@ class TestElasticsearch:
         else:
             # Prev versions don't use int8_hnsw quantization default
             # We expect an exact match on score for older versions
-            assert score == 1.0 
+            assert score == 1.0
 
     @pytest.mark.asyncio
     async def test_similarity_search_bm25_search(

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -175,7 +175,24 @@ class TestElasticsearch:
                     "filter": [],
                     "k": 1,
                     "num_candidates": 50,
-                    "query_vector": [0.06, 0.07, 0.01, 0.08, 0.03, 0.07, 0.09, 0.03, 0.09, 0.09, 0.04, 0.03, 0.08, 0.07, 0.06, 0.08],
+                    "query_vector": [
+                        0.06,
+                        0.07,
+                        0.01,
+                        0.08,
+                        0.03,
+                        0.07,
+                        0.09,
+                        0.03,
+                        0.09,
+                        0.09,
+                        0.04,
+                        0.03,
+                        0.08,
+                        0.07,
+                        0.06,
+                        0.08,
+                    ],
                 }
             }
             return query_body
@@ -611,6 +628,7 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
+
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -169,15 +169,15 @@ class TestElasticsearch:
         def assert_query(
             query_body: Dict[str, Any], query: Optional[str]
         ) -> Dict[str, Any]:
-            assert "knn" in query_body
-            knn = query_body["knn"]
-            assert knn["field"] == "vector"
-            assert knn["k"] == 1
-            assert knn["num_candidates"] == 50
-            assert knn["filter"] == []
-            assert (
-                isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
-            )
+            assert query_body == {
+                "knn": {
+                    "field": "vector",
+                    "filter": [],
+                    "k": 1,
+                    "num_candidates": 50,
+                    "query_vector": [0.06, 0.07, 0.01, 0.08, 0.03, 0.07, 0.09, 0.03, 0.09, 0.09, 0.04, 0.03, 0.08, 0.07, 0.06, 0.08],
+                }
+            }
             return query_body
 
         texts = ["foo", "bar", "baz"]

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -601,18 +601,9 @@ class TestElasticsearch:
             custom_query=assert_query,
         )
         doc, score = output[0]
+
         assert doc == Document(page_content="foo")
-        info = await docsearch.client.info()
-        es_version = info["version"]["number"]
-        major, minor = map(int, es_version.split(".")[:2])
-        if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance delta
-            # See comment on ASyncStableHashEmbeddings class for more details
-            assert score == pytest.approx(1.0, rel=0.05)
-        else:
-            # Prev versions don't use int8_hnsw quantization default
-            # We expect an exact match on score for older versions
-            assert score == 1.0
+        assert score == pytest.approx(1.0, rel=0.05)
 
     @pytest.mark.asyncio
     async def test_similarity_search_approx_with_hybrid_search_rrf(
@@ -822,19 +813,9 @@ class TestElasticsearch:
             embedding=embedded_query, k=1
         )
         doc, score = output[0]
+
         assert doc == Document(page_content="foo", metadata={"page": "0"})
-        # Use the client to pick a tolernace for based on ES version
-        info = await docsearch.client.info()
-        es_version = info["version"]["number"]
-        major, minor = map(int, es_version.split(".")[:2])
-        if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance delta
-            # See comment on ASyncStableHashEmbeddings class for more details
-            assert score == pytest.approx(1.0, rel=0.05)
-        else:
-            # Prev versions don't use int8_hnsw quantization default
-            # We expect an exact match on score for older versions
-            assert score == 1.0
+        assert score == pytest.approx(1.0, rel=0.05)
 
     @pytest.mark.asyncio
     async def test_similarity_search_bm25_search(

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -626,7 +626,7 @@ class TestElasticsearch:
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, "window_size": 5},
+            {"rank_constant": 1, "rank_window_size": 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -703,7 +703,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, "window_size": 5}},
+            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
         )
 
         assert [o.page_content for o in output] == [

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -807,7 +807,7 @@ class TestElasticsearch:
             # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match is expected
+            # earlier versions don't use quantization by default so exact match needed
             assert score == 1.0 
 
     @pytest.mark.asyncio

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -176,7 +176,10 @@ class TestElasticsearch:
             assert knn["k"] == 1
             assert knn["num_candidates"] == 50
             assert knn["filter"] == []
-            assert isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
+            assert (
+                isinstance(knn["query_vector"], list) 
+                and len(knn["query_vector"]) == 10
+            )
             return query_body
 
         texts = ["foo", "bar", "baz"]

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -622,13 +622,17 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
-        #Check version of ES because ES 8.15+ requires rank_window_size instead of window_size
+        #Check version of ES
+        #ES 8.15+ requires rank_window_size instead of window_size
         _es = create_es_client(es_params)
         try:
             _info = await _es.info()
             _version = _info["version"]["number"]
             _major, _minor = map(int, _version.split(".")[:2])
-            window_key = "rank_window_size" if ( _major, _minor) >= (8, 15) else "window_size"
+            if ( _major, _minor) >= (8, 15):
+                window_key = "rank_window_size"    
+            else:
+                window_key = "window_size"
         finally:
             await _es.close()
             

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -608,10 +608,12 @@ class TestElasticsearch:
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
         if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            # if ES 8.14+ then relax the assertion to a tolerance delta
+            # See comment on ASyncStableHashEmbeddings class for more details
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match needed
+            # Prev versions don't use int8_hnsw quantization default
+            # We expect an exact match on score for older versions
             assert score == 1.0 
 
 
@@ -829,10 +831,12 @@ class TestElasticsearch:
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
         if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            # if ES 8.14+ then relax the assertion to a tolerance delta
+            # See comment on ASyncStableHashEmbeddings class for more details
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match needed
+            # Prev versions don't use int8_hnsw quantization default
+            # We expect an exact match on score for older versions
             assert score == 1.0 
 
     @pytest.mark.asyncio

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -204,7 +204,7 @@ class TestElasticsearch:
         For example, your embedding text can be a question, whereas page_content
          is the answer.
         """
-        embeddings = AsyncConsistentFakeEmbeddings()
+        embeddings = AsyncStableHashEmbeddings()
         text_input = ["foo1", "foo2", "foo3"]
         metadatas = [{"page": i} for i in range(len(text_input))]
 

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -10,7 +10,11 @@ from langchain_core.documents import Document
 
 from langchain_elasticsearch.vectorstores import AsyncElasticsearchStore
 
-from ...fake_embeddings import AsyncConsistentFakeEmbeddings, AsyncFakeEmbeddings, AsyncStableHashEmbeddings
+from ...fake_embeddings import (
+    AsyncConsistentFakeEmbeddings,
+    AsyncFakeEmbeddings,
+    AsyncStableHashEmbeddings,
+)
 from ._test_utilities import clear_test_indices, create_es_client, read_env
 
 logging.basicConfig(level=logging.DEBUG)

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -622,11 +622,21 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
+        #Check version of ES because ES 8.15+ requires rank_window_size instead of window_size
+        _es = create_es_client(es_params)
+        try:
+            _info = await _es.info()
+            _version = _info["version"]["number"]
+            _major, _minor = map(int, _version.split(".")[:2])
+            window_key = "rank_window_size" if ( _major, _minor) >= (8, 15) else "window_size"
+        finally:
+            await _es.close()
+            
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, "rank_window_size": 5},
+            {"rank_constant": 1, window_key: 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -703,7 +713,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
+            rank={"rrf": {"rank_constant": 1, window_key: 5}},
         )
 
         assert [o.page_content for o in output] == [

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -611,26 +611,11 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
-
-        # Check version of ES
-        # ES 8.15+ requires rank_window_size instead of window_size
-        _es = create_es_client(es_params)
-        try:
-            _info = await _es.info()
-            _version = _info["version"]["number"]
-            _major, _minor = map(int, _version.split(".")[:2])
-            if (_major, _minor) >= (8, 15):
-                window_key = "rank_window_size"
-            else:
-                window_key = "window_size"
-        finally:
-            await _es.close()
-
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, window_key: 5},
+            {"rank_constant": 1, "rank_window_size": 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -707,7 +692,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, window_key: 5}},
+            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
         )
 
         assert [o.page_content for o in output] == [

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -783,7 +783,7 @@ class TestElasticsearch:
         """Test to make sure the relevance score is scaled to 0-1."""
         texts = ["foo", "bar", "baz"]
         metadatas = [{"page": str(i)} for i in range(len(texts))]
-        embeddings = AsyncFakeEmbeddings()
+        embeddings = AsyncStableHashEmbeddings()
 
         docsearch = await AsyncElasticsearchStore.afrom_texts(
             index_name=index_name,

--- a/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_async/test_vectorstores.py
@@ -13,7 +13,6 @@ from langchain_elasticsearch.vectorstores import AsyncElasticsearchStore
 from ...fake_embeddings import (
     AsyncConsistentFakeEmbeddings,
     AsyncFakeEmbeddings,
-    AsyncStableHashEmbeddings,
 )
 from ._test_utilities import clear_test_indices, create_es_client, read_env
 
@@ -184,7 +183,7 @@ class TestElasticsearch:
         texts = ["foo", "bar", "baz"]
         docsearch = await AsyncElasticsearchStore.afrom_texts(
             texts,
-            AsyncStableHashEmbeddings(),
+            AsyncConsistentFakeEmbeddings(),
             **es_params,
             index_name=index_name,
         )
@@ -203,7 +202,7 @@ class TestElasticsearch:
         For example, your embedding text can be a question, whereas page_content
          is the answer.
         """
-        embeddings = AsyncStableHashEmbeddings()
+        embeddings = AsyncConsistentFakeEmbeddings()
         text_input = ["foo1", "foo2", "foo3"]
         metadatas = [{"page": i} for i in range(len(text_input))]
 
@@ -572,7 +571,7 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and search with metadata."""
         texts = ["foo", "bar", "baz"]
-        embeddings = AsyncStableHashEmbeddings()
+        embeddings = AsyncConsistentFakeEmbeddings()
         docsearch = await AsyncElasticsearchStore.afrom_texts(
             texts,
             embedding=embeddings,
@@ -778,7 +777,7 @@ class TestElasticsearch:
         with pytest.raises(NotFoundError):
             await AsyncElasticsearchStore.afrom_texts(
                 texts=["foo", "bar", "baz"],
-                embedding=AsyncConsistentFakeEmbeddings(10),
+                embedding=AsyncConsistentFakeEmbeddings(),
                 **es_params,
                 index_name=index_name,
                 strategy=AsyncElasticsearchStore.ApproxRetrievalStrategy(
@@ -808,7 +807,7 @@ class TestElasticsearch:
         """Test to make sure the relevance score is scaled to 0-1."""
         texts = ["foo", "bar", "baz"]
         metadatas = [{"page": str(i)} for i in range(len(texts))]
-        embeddings = AsyncStableHashEmbeddings()
+        embeddings = AsyncConsistentFakeEmbeddings()
 
         docsearch = await AsyncElasticsearchStore.afrom_texts(
             index_name=index_name,

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -609,7 +609,7 @@ class TestElasticsearch:
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, "window_size": 5},
+            {"rank_constant": 1, "rank_window_size": 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -686,7 +686,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, "window_size": 5}},
+            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
         )
 
         assert [o.page_content for o in output] == [

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -13,7 +13,6 @@ from langchain_elasticsearch.vectorstores import ElasticsearchStore
 from ...fake_embeddings import (
     ConsistentFakeEmbeddings,
     FakeEmbeddings,
-    StableHashEmbeddings,
 )
 from ._test_utilities import clear_test_indices, create_es_client, read_env
 
@@ -184,7 +183,7 @@ class TestElasticsearch:
         texts = ["foo", "bar", "baz"]
         docsearch = ElasticsearchStore.from_texts(
             texts,
-            StableHashEmbeddings(),
+            ConsistentFakeEmbeddings(),
             **es_params,
             index_name=index_name,
         )
@@ -201,7 +200,7 @@ class TestElasticsearch:
         For example, your embedding text can be a question, whereas page_content
          is the answer.
         """
-        embeddings = StableHashEmbeddings()
+        embeddings = ConsistentFakeEmbeddings()
         text_input = ["foo1", "foo2", "foo3"]
         metadatas = [{"page": i} for i in range(len(text_input))]
 
@@ -556,7 +555,7 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and search with metadata."""
         texts = ["foo", "bar", "baz"]
-        embeddings = StableHashEmbeddings()
+        embeddings = ConsistentFakeEmbeddings()
         docsearch = ElasticsearchStore.from_texts(
             texts,
             embedding=embeddings,
@@ -760,7 +759,7 @@ class TestElasticsearch:
         with pytest.raises(NotFoundError):
             ElasticsearchStore.from_texts(
                 texts=["foo", "bar", "baz"],
-                embedding=ConsistentFakeEmbeddings(10),
+                embedding=ConsistentFakeEmbeddings(),
                 **es_params,
                 index_name=index_name,
                 strategy=ElasticsearchStore.ApproxRetrievalStrategy(
@@ -790,7 +789,7 @@ class TestElasticsearch:
         """Test to make sure the relevance score is scaled to 0-1."""
         texts = ["foo", "bar", "baz"]
         metadatas = [{"page": str(i)} for i in range(len(texts))]
-        embeddings = StableHashEmbeddings()
+        embeddings = ConsistentFakeEmbeddings()
 
         docsearch = ElasticsearchStore.from_texts(
             index_name=index_name,

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -613,25 +613,11 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
-        # Check version of ES
-        # ES 8.15+ requires rank_window_size instead of window_size
-        _es = create_es_client(es_params)
-        try:
-            _info = _es.info()
-            _version = _info["version"]["number"]
-            _major, _minor = map(int, _version.split(".")[:2])
-            if (_major, _minor) >= (8, 15):
-                window_key = "rank_window_size"
-            else:
-                window_key = "window_size"
-        finally:
-            _es.close()
-
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, window_key: 5},
+            {"rank_constant": 1, "rank_window_size": 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -708,7 +694,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, window_key: 5}},
+            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
         )
 
         assert [o.page_content for o in output] == [
@@ -812,19 +798,9 @@ class TestElasticsearch:
             embedding=embedded_query, k=1
         )
         doc, score = output[0]
+
         assert doc == Document(page_content="foo", metadata={"page": "0"})
-        # Use the client to pick a tolernace for based on ES version
-        info = docsearch.client.info()
-        es_version = info["version"]["number"]
-        major, minor = map(int, es_version.split(".")[:2])
-        if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance delta
-            # See comment on ASyncStableHashEmbeddings class for more details
-            assert score == pytest.approx(1.0, rel=0.05)
-        else:
-            # Prev versions don't use int8_hnsw quantization default
-            # We expect an exact match on score for older versions
-            assert score == 1.0
+        assert score == pytest.approx(1.0, rel=0.05)
 
     @pytest.mark.sync
     def test_similarity_search_bm25_search(

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -175,7 +175,24 @@ class TestElasticsearch:
                     "filter": [],
                     "k": 1,
                     "num_candidates": 50,
-                    "query_vector": [0.06, 0.07, 0.01, 0.08, 0.03, 0.07, 0.09, 0.03, 0.09, 0.09, 0.04, 0.03, 0.08, 0.07, 0.06, 0.08],
+                    "query_vector": [
+                        0.06,
+                        0.07,
+                        0.01,
+                        0.08,
+                        0.03,
+                        0.07,
+                        0.09,
+                        0.03,
+                        0.09,
+                        0.09,
+                        0.04,
+                        0.03,
+                        0.08,
+                        0.07,
+                        0.06,
+                        0.08,
+                    ],
                 }
             }
             return query_body
@@ -585,18 +602,9 @@ class TestElasticsearch:
             custom_query=assert_query,
         )
         doc, score = output[0]
+
         assert doc == Document(page_content="foo")
-        info = docsearch.client.info()
-        es_version = info["version"]["number"]
-        major, minor = map(int, es_version.split(".")[:2])
-        if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance delta
-            # See comment on StableHashEmbeddings class for more details
-            assert score == pytest.approx(1.0, rel=0.05)
-        else:
-            # Prev versions don't use int8_hnsw quantization default
-            # We expect an exact match on score for older versions
-            assert score == 1.0
+        assert score == pytest.approx(1.0, rel=0.05)
 
     @pytest.mark.sync
     def test_similarity_search_approx_with_hybrid_search_rrf(
@@ -811,7 +819,7 @@ class TestElasticsearch:
         major, minor = map(int, es_version.split(".")[:2])
         if (major, minor) >= (8, 14):
             # if ES 8.14+ then relax the assertion to a tolerance delta
-            # See comment on StableHashEmbeddings class for more details
+            # See comment on ASyncStableHashEmbeddings class for more details
             assert score == pytest.approx(1.0, rel=0.05)
         else:
             # Prev versions don't use int8_hnsw quantization default

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -10,7 +10,11 @@ from langchain_core.documents import Document
 
 from langchain_elasticsearch.vectorstores import ElasticsearchStore
 
-from ...fake_embeddings import ConsistentFakeEmbeddings, FakeEmbeddings, StableHashEmbeddings
+from ...fake_embeddings import (
+    ConsistentFakeEmbeddings,
+    FakeEmbeddings,
+    StableHashEmbeddings,
+)
 from ._test_utilities import clear_test_indices, create_es_client, read_env
 
 logging.basicConfig(level=logging.DEBUG)

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -592,10 +592,12 @@ class TestElasticsearch:
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
         if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            # if ES 8.14+ then relax the assertion to a tolerance delta
+            # See comment on StableHashEmbeddings class for more details
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match needed
+            # Prev versions don't use int8_hnsw quantization default
+            # We expect an exact match on score for older versions
             assert score == 1.0 
 
     @pytest.mark.sync
@@ -810,10 +812,12 @@ class TestElasticsearch:
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
         if (major, minor) >= (8, 14):
-            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            # if ES 8.14+ then relax the assertion to a tolerance delta
+            # See comment on StableHashEmbeddings class for more details
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match needed
+            # Prev versions don't use int8_hnsw quantization default
+            # We expect an exact match on score for older versions
             assert score == 1.0 
 
     @pytest.mark.sync

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -169,15 +169,15 @@ class TestElasticsearch:
         def assert_query(
             query_body: Dict[str, Any], query: Optional[str]
         ) -> Dict[str, Any]:
-            assert "knn" in query_body
-            knn = query_body["knn"]
-            assert knn["field"] == "vector"
-            assert knn["k"] == 1
-            assert knn["num_candidates"] == 50
-            assert knn["filter"] == []
-            assert (
-                isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
-            )
+            assert query_body == {
+                "knn": {
+                    "field": "vector",
+                    "filter": [],
+                    "k": 1,
+                    "num_candidates": 50,
+                    "query_vector": [0.06, 0.07, 0.01, 0.08, 0.03, 0.07, 0.09, 0.03, 0.09, 0.09, 0.04, 0.03, 0.08, 0.07, 0.06, 0.08],
+                }
+            }
             return query_body
 
         texts = ["foo", "bar", "baz"]

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -557,7 +557,7 @@ class TestElasticsearch:
     ) -> None:
         """Test end to end construction and search with metadata."""
         texts = ["foo", "bar", "baz"]
-        embeddings = ConsistentFakeEmbeddings()
+        embeddings = StableHashEmbeddings()
         docsearch = ElasticsearchStore.from_texts(
             texts,
             embedding=embeddings,

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -10,7 +10,7 @@ from langchain_core.documents import Document
 
 from langchain_elasticsearch.vectorstores import ElasticsearchStore
 
-from ...fake_embeddings import ConsistentFakeEmbeddings, FakeEmbeddings
+from ...fake_embeddings import ConsistentFakeEmbeddings, FakeEmbeddings, StableHashEmbeddings
 from ._test_utilities import clear_test_indices, create_es_client, read_env
 
 logging.basicConfig(level=logging.DEBUG)
@@ -166,21 +166,19 @@ class TestElasticsearch:
         def assert_query(
             query_body: Dict[str, Any], query: Optional[str]
         ) -> Dict[str, Any]:
-            assert query_body == {
-                "knn": {
-                    "field": "vector",
-                    "filter": [],
-                    "k": 1,
-                    "num_candidates": 50,
-                    "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
-                }
-            }
+            assert "knn" in query_body
+            knn = query_body["knn"]
+            assert knn["field"] == "vector"
+            assert knn["k"] == 1
+            assert knn["num_candidates"] == 50
+            assert knn["filter"] == []
+            assert isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
             return query_body
 
         texts = ["foo", "bar", "baz"]
         docsearch = ElasticsearchStore.from_texts(
             texts,
-            FakeEmbeddings(),
+            StableHashEmbeddings(),
             **es_params,
             index_name=index_name,
         )

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -177,8 +177,7 @@ class TestElasticsearch:
             assert knn["num_candidates"] == 50
             assert knn["filter"] == []
             assert (
-                isinstance(knn["query_vector"], list) 
-                and len(knn["query_vector"]) == 10
+                isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
             )
             return query_body
 
@@ -598,7 +597,7 @@ class TestElasticsearch:
         else:
             # Prev versions don't use int8_hnsw quantization default
             # We expect an exact match on score for older versions
-            assert score == 1.0 
+            assert score == 1.0
 
     @pytest.mark.sync
     def test_similarity_search_approx_with_hybrid_search_rrf(
@@ -607,15 +606,15 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
-        #Check version of ES 
+        # Check version of ES
         # ES 8.15+ requires rank_window_size instead of window_size
         _es = create_es_client(es_params)
         try:
             _info = _es.info()
             _version = _info["version"]["number"]
             _major, _minor = map(int, _version.split(".")[:2])
-            if ( _major, _minor) >= (8, 15):
-                window_key = "rank_window_size" 
+            if (_major, _minor) >= (8, 15):
+                window_key = "rank_window_size"
             else:
                 window_key = "window_size"
         finally:
@@ -807,7 +806,7 @@ class TestElasticsearch:
         )
         doc, score = output[0]
         assert doc == Document(page_content="foo", metadata={"page": "0"})
-        #Use the client to pick a tolernace for based on ES version
+        # Use the client to pick a tolernace for based on ES version
         info = docsearch.client.info()
         es_version = info["version"]["number"]
         major, minor = map(int, es_version.split(".")[:2])
@@ -818,7 +817,7 @@ class TestElasticsearch:
         else:
             # Prev versions don't use int8_hnsw quantization default
             # We expect an exact match on score for older versions
-            assert score == 1.0 
+            assert score == 1.0
 
     @pytest.mark.sync
     def test_similarity_search_bm25_search(

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -605,13 +605,17 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
-        #Check version of ES because ES 8.15+ requires rank_window_size instead of window_size
+        #Check version of ES 
+        # ES 8.15+ requires rank_window_size instead of window_size
         _es = create_es_client(es_params)
         try:
             _info = _es.info()
             _version = _info["version"]["number"]
             _major, _minor = map(int, _version.split(".")[:2])
-            window_key = "rank_window_size" if ( _major, _minor) >= (8, 15) else "window_size"
+            if ( _major, _minor) >= (8, 15):
+                window_key = "rank_window_size" 
+            else:
+                window_key = "window_size"
         finally:
             _es.close()
 

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -789,7 +789,7 @@ class TestElasticsearch:
             # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
             assert score == pytest.approx(1.0, rel=0.05)
         else:
-            # earlier versions don't use quantization by default so exact match is expected
+            # earlier versions don't use quantization by default so exact match needed
             assert score == 1.0 
 
     @pytest.mark.sync

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -176,7 +176,10 @@ class TestElasticsearch:
             assert knn["k"] == 1
             assert knn["num_candidates"] == 50
             assert knn["filter"] == []
-            assert isinstance(knn["query_vector"], list) and len(knn["query_vector"]) == 10
+            assert (
+                isinstance(knn["query_vector"], list) 
+                and len(knn["query_vector"]) == 10
+            )
             return query_body
 
         texts = ["foo", "bar", "baz"]

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -586,7 +586,17 @@ class TestElasticsearch:
             k=1,
             custom_query=assert_query,
         )
-        assert output == [(Document(page_content="foo"), 1.0)]
+        doc, score = output[0]
+        assert doc == Document(page_content="foo")
+        info = docsearch.client.info()
+        es_version = info["version"]["number"]
+        major, minor = map(int, es_version.split(".")[:2])
+        if (major, minor) >= (8, 14):
+            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            assert score == pytest.approx(1.0, rel=0.05)
+        else:
+            # earlier versions don't use quantization by default so exact match needed
+            assert score == 1.0 
 
     @pytest.mark.sync
     def test_similarity_search_approx_with_hybrid_search_rrf(

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -779,7 +779,18 @@ class TestElasticsearch:
         output = docsearch.similarity_search_by_vector_with_relevance_scores(
             embedding=embedded_query, k=1
         )
-        assert output == [(Document(page_content="foo", metadata={"page": "0"}), 1.0)]
+        doc, score = output[0]
+        assert doc == Document(page_content="foo", metadata={"page": "0"})
+        #Use the client to pick a tolernace for based on ES version
+        info = docsearch.client.info()
+        es_version = info["version"]["number"]
+        major, minor = map(int, es_version.split(".")[:2])
+        if (major, minor) >= (8, 14):
+            # if ES 8.14+ then relax the assertion to a tolerance to 1e-5
+            assert score == pytest.approx(1.0, rel=0.05)
+        else:
+            # earlier versions don't use quantization by default so exact match is expected
+            assert score == 1.0 
 
     @pytest.mark.sync
     def test_similarity_search_bm25_search(

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -605,11 +605,21 @@ class TestElasticsearch:
         """Test end to end construction and rrf hybrid search with metadata."""
         from functools import partial
 
+        #Check version of ES because ES 8.15+ requires rank_window_size instead of window_size
+        _es = create_es_client(es_params)
+        try:
+            _info = _es.info()
+            _version = _info["version"]["number"]
+            _major, _minor = map(int, _version.split(".")[:2])
+            window_key = "rank_window_size" if ( _major, _minor) >= (8, 15) else "window_size"
+        finally:
+            _es.close()
+
         # 1. check query_body is okay
         rrf_test_cases: List[Optional[Union[dict, bool]]] = [
             True,
             False,
-            {"rank_constant": 1, "rank_window_size": 5},
+            {"rank_constant": 1, window_key: 5},
         ]
         for rrf_test_case in rrf_test_cases:
             texts = ["foo", "bar", "baz"]
@@ -686,7 +696,7 @@ class TestElasticsearch:
                 "query_vector": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
             },
             size=3,
-            rank={"rrf": {"rank_constant": 1, "rank_window_size": 5}},
+            rank={"rrf": {"rank_constant": 1, window_key: 5}},
         )
 
         assert [o.page_content for o in output] == [

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -765,7 +765,7 @@ class TestElasticsearch:
         """Test to make sure the relevance score is scaled to 0-1."""
         texts = ["foo", "bar", "baz"]
         metadatas = [{"page": str(i)} for i in range(len(texts))]
-        embeddings = FakeEmbeddings()
+        embeddings = StableHashEmbeddings()
 
         docsearch = ElasticsearchStore.from_texts(
             index_name=index_name,

--- a/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/integration_tests/_sync/test_vectorstores.py
@@ -202,7 +202,7 @@ class TestElasticsearch:
         For example, your embedding text can be a question, whereas page_content
          is the answer.
         """
-        embeddings = ConsistentFakeEmbeddings()
+        embeddings = StableHashEmbeddings()
         text_input = ["foo1", "foo2", "foo3"]
         metadatas = [{"page": i} for i in range(len(text_input))]
 


### PR DESCRIPTION
**Issue**
Create testing matrix for various python versions and ES versions
Closes https://github.com/elastic/devtools-integrations/issues/37

**Strategy for fix**
Initially making FakeEmbeddings return less uniform vectors for embeddings (2x factor on the last value of each array for a text) was considered which fixed the test_similarity_search_without_metadata but for other tests i found myself using random factors to get the tests to pass like 4x. There seemed to be no consistent factor which I felt was not satisfactory 

The ConsistentFakeEmbeddings class was updated instead to use MD5 hashing to create well-separated, deterministic vectors so that small quantisation/ANN error doesn't effect ranking when doing things like similarity searches. We could do exact searches like ExactRetrievalStrategy instead of defaulting to ApproxRetrievalStrategy but to keep the same spirit of the test it seemed better to introduce stable hash based embeddings

We also had to relax some strict 1.0 scoring assertions when ES version was >= 8.14 since quantization means scoring will not be perfect match. For this, we introduce a small tolerance delta to check score value on versions of ES >=8.14

~~We also check version of ES when deciding to do 'rank_window_size' or 'window_size' in payload for the RRF tests~~
This is no longer needed as the minimum version of ES we are now testing in our matrix is 8.15 so just using rank_window_size is enough 

