### PR TITLE
Add `aiohttp` test dependancy

### DIFF
--- a/libs/elasticsearch/pyproject.toml
+++ b/libs/elasticsearch/pyproject.toml
@@ -26,6 +26,7 @@ syrupy = "^4.0.2"
 pytest-watcher = "^0.3.4"
 pytest-asyncio = "^0.21.1"
 langchain = ">=0.3.10,<1.0.0"
+aiohttp = "^3.8.3"
 
 [tool.poetry.group.codespell]
 optional = true


### PR DESCRIPTION
As part of the release 0.4.0, [this](https://github.com/langchain-ai/langchain-elastic/pull/80) PR was merged with all CI tests passing

However when i tried to run the release workflow, the pre release checks failed. You can find the full logs [here](https://github.com/langchain-ai/langchain-elastic/actions/runs/18885290267/job/53899045659)

The main issue is that poetry does not install `aiohttp` anymore, this might be due to the fact that we simplified our langchain dependancies. We need to explicitly add it to the pyproject toml 

I chose to add `"^3.8.3"` because previously in the lock file we had it defined it similarly