### PR TITLE
add carat version for `langchain-core`

### DIFF
--- a/libs/elasticsearch/pyproject.toml
+++ b/libs/elasticsearch/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = ">=0.3.0"
+langchain-core = "^0.3.0"
 elasticsearch = {version = ">=8.16.0,<9.0.0", extras = ["vectorstore_mmr"]}
 
 [tool.poetry.group.test]


### PR DESCRIPTION
```
"""
Run poetry run pip install packaging
Requirement already satisfied: packaging in /home/runner/.cache/pypoetry/virtualenvs/langchain-elasticsearch-KycTYW9z-py3.11/lib/python3.11/site-packages (25.0)

Notice:  A new release of pip is available: 25.2 -> 25.3
Notice:  To update, run: pip install --upgrade pip
Traceback (most recent call last):
  File "/home/runner/work/langchain-elastic/langchain-elastic/.github/scripts/get_min_versions.py", line 83, in <module>
    min_versions = get_min_version_from_toml(toml_file, versions_for)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/langchain-elastic/langchain-elastic/.github/scripts/get_min_versions.py", line 68, in get_min_version_from_toml
    min_version = get_min_version(version_string)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/langchain-elastic/langchain-elastic/.github/scripts/get_min_versions.py", line 39, in get_min_version
    raise ValueError(f"Unrecognized version format: {version}")
ValueError: Unrecognized version format: >=0.3.0
"""
```

Changing to carat versioning for this error when trying release. Avoiding v1 of langchain-core since we can support that when we release v1 of langchain-elastic 
<img width="788" height="699" alt="Screenshot 2025-10-29 at 11 07 41 AM" src="https://github.com/user-attachments/assets/2556623b-e742-4811-be2a-b4a79770b633" />

