### PR TITLE
Allow query embeddings to be passed in max_marginal_relevance_search

### DIFF
--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -553,7 +553,7 @@ class AsyncElasticsearchStore(VectorStore):
         query_embedding = cast(
             Optional[List[float]], kwargs.pop("query_embedding", None)
         )
-        query_for_store: Optional[str] = query if query else None
+        query_for_store = query if query else None
 
         # Require at least one input, either query text or query embedding.
         if query_for_store is None and query_embedding is None:

--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -565,7 +565,6 @@ class AsyncElasticsearchStore(VectorStore):
             raise ValueError("specify embedding_service to search with query")
 
         hits = await self._store.max_marginal_relevance_search(
-            embedding_service=self._embedding_service,
             query=query_for_store,
             query_embedding=query_embedding,
             vector_field=self.vector_query_field,

--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -555,9 +555,12 @@ class AsyncElasticsearchStore(VectorStore):
         )
         query_for_store: Optional[str] = query if query else None
 
+        # Require at least one input, either query text or query embedding.
         if query_for_store is None and query_embedding is None:
             raise ValueError("specify either query or query_embedding to search")
 
+        # If no precomputed query embedding is provided, query text path
+        # needs an embedding service to generate the query vector.
         if query_embedding is None and self._embedding_service is None:
             raise ValueError("specify embedding_service to search with query")
 

--- a/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_async/vectorstores.py
@@ -1,5 +1,16 @@
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from elasticsearch import AsyncElasticsearch
 from elasticsearch.helpers.vectorstore import (
@@ -506,7 +517,7 @@ class AsyncElasticsearchStore(VectorStore):
 
     async def amax_marginal_relevance_search(
         self,
-        query: str,
+        query: str = "",
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
@@ -525,6 +536,8 @@ class AsyncElasticsearchStore(VectorStore):
 
         Args:
             query (str): Text to look up documents similar to.
+            query_embedding (Optional[List[float]]): Input embedding vector.
+                If given, input query string is ignored.
             k (int): Number of Documents to return. Defaults to 4.
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree
@@ -537,14 +550,21 @@ class AsyncElasticsearchStore(VectorStore):
         Returns:
             List[Document]: A list of Documents selected by maximal marginal relevance.
         """
-        if self._embedding_service is None:
-            raise ValueError(
-                "maximal marginal relevance search requires an embedding service."
-            )
+        query_embedding = cast(
+            Optional[List[float]], kwargs.pop("query_embedding", None)
+        )
+        query_for_store: Optional[str] = query if query else None
+
+        if query_for_store is None and query_embedding is None:
+            raise ValueError("specify either query or query_embedding to search")
+
+        if query_embedding is None and self._embedding_service is None:
+            raise ValueError("specify embedding_service to search with query")
 
         hits = await self._store.max_marginal_relevance_search(
             embedding_service=self._embedding_service,
-            query=query,
+            query=query_for_store,
+            query_embedding=query_embedding,
             vector_field=self.vector_query_field,
             k=k,
             num_candidates=fetch_k,

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -555,9 +555,12 @@ class ElasticsearchStore(VectorStore):
         )
         query_for_store: Optional[str] = query if query else None
 
+        # Require at least one input, either query text or query embedding.
         if query_for_store is None and query_embedding is None:
             raise ValueError("specify either query or query_embedding to search")
 
+        # If no precomputed query embedding is provided, query text path
+        # needs an embedding service to generate the query vector.
         if query_embedding is None and self._embedding_service is None:
             raise ValueError("specify embedding_service to search with query")
 

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -1,5 +1,16 @@
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers.vectorstore import (
@@ -506,7 +517,7 @@ class ElasticsearchStore(VectorStore):
 
     def max_marginal_relevance_search(
         self,
-        query: str,
+        query: str = "",
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
@@ -525,6 +536,8 @@ class ElasticsearchStore(VectorStore):
 
         Args:
             query (str): Text to look up documents similar to.
+            query_embedding (Optional[List[float]]): Input embedding vector.
+                If given, input query string is ignored.
             k (int): Number of Documents to return. Defaults to 4.
             fetch_k (int): Number of Documents to fetch to pass to MMR algorithm.
             lambda_mult (float): Number between 0 and 1 that determines the degree
@@ -537,14 +550,21 @@ class ElasticsearchStore(VectorStore):
         Returns:
             List[Document]: A list of Documents selected by maximal marginal relevance.
         """
-        if self._embedding_service is None:
-            raise ValueError(
-                "maximal marginal relevance search requires an embedding service."
-            )
+        query_embedding = cast(
+            Optional[List[float]], kwargs.pop("query_embedding", None)
+        )
+        query_for_store: Optional[str] = query if query else None
+
+        if query_for_store is None and query_embedding is None:
+            raise ValueError("specify either query or query_embedding to search")
+
+        if query_embedding is None and self._embedding_service is None:
+            raise ValueError("specify embedding_service to search with query")
 
         hits = self._store.max_marginal_relevance_search(
             embedding_service=self._embedding_service,
-            query=query,
+            query=query_for_store,
+            query_embedding=query_embedding,
             vector_field=self.vector_query_field,
             k=k,
             num_candidates=fetch_k,

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    cast,
 )
 
 from elasticsearch import Elasticsearch
@@ -515,9 +514,10 @@ class ElasticsearchStore(VectorStore):
         )
         return [doc for doc, _score in docs]
 
-    def max_marginal_relevance_search(
+    def max_marginal_relevance_search(  # type: ignore[override]
         self,
-        query: str = "",
+        query: Optional[str] = None,
+        query_embedding: Optional[List[float]] = None,
         k: int = 4,
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
@@ -535,7 +535,7 @@ class ElasticsearchStore(VectorStore):
             among selected documents.
 
         Args:
-            query (str): Text to look up documents similar to.
+            query (Optional[str]): Text to look up documents similar to.
             query_embedding (Optional[List[float]]): Input embedding vector.
                 If given, input query string is ignored.
             k (int): Number of Documents to return. Defaults to 4.
@@ -550,22 +550,17 @@ class ElasticsearchStore(VectorStore):
         Returns:
             List[Document]: A list of Documents selected by maximal marginal relevance.
         """
-        query_embedding = cast(
-            Optional[List[float]], kwargs.pop("query_embedding", None)
-        )
-        query_for_store = query if query else None
-
         # Require at least one input, either query text or query embedding.
-        if query_for_store is None and query_embedding is None:
+        if query is None and query_embedding is None:
             raise ValueError("specify either query or query_embedding to search")
 
         # If no precomputed query embedding is provided, query text path
         # needs an embedding service to generate the query vector.
-        if query_embedding is None and self._embedding_service is None:
+        if query is not None and self._embedding_service is None:
             raise ValueError("specify embedding_service to search with query")
 
         hits = self._store.max_marginal_relevance_search(
-            query=query_for_store,
+            query=query,
             query_embedding=query_embedding,
             vector_field=self.vector_query_field,
             k=k,

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -553,7 +553,7 @@ class ElasticsearchStore(VectorStore):
         query_embedding = cast(
             Optional[List[float]], kwargs.pop("query_embedding", None)
         )
-        query_for_store: Optional[str] = query if query else None
+        query_for_store = query if query else None
 
         # Require at least one input, either query text or query embedding.
         if query_for_store is None and query_embedding is None:

--- a/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
+++ b/libs/elasticsearch/langchain_elasticsearch/_sync/vectorstores.py
@@ -565,7 +565,6 @@ class ElasticsearchStore(VectorStore):
             raise ValueError("specify embedding_service to search with query")
 
         hits = self._store.max_marginal_relevance_search(
-            embedding_service=self._embedding_service,
             query=query_for_store,
             query_embedding=query_embedding,
             vector_field=self.vector_query_field,

--- a/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
@@ -438,6 +438,15 @@ class TestVectorStore:
         )
 
     @pytest.mark.asyncio
+    async def test_max_marginal_relevance_search_requires_query_or_embedding(
+        self, store: AsyncElasticsearchStore
+    ) -> None:
+        with pytest.raises(
+            ValueError, match="specify either query or query_embedding to search"
+        ):
+            await store.amax_marginal_relevance_search()
+
+    @pytest.mark.asyncio
     async def test_elasticsearch_hybrid_scores_guard(
         self, hybrid_store: AsyncElasticsearchStore
     ) -> None:

--- a/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
@@ -19,7 +19,7 @@ from langchain_elasticsearch._async.vectorstores import (
     _convert_retrieval_strategy,
 )
 from langchain_elasticsearch._utilities import _hits_to_docs_scores
-from langchain_elasticsearch.embeddings import AsyncEmbeddingServiceAdapter, Embeddings
+from langchain_elasticsearch.embeddings import Embeddings
 from langchain_elasticsearch.vectorstores import (
     AsyncElasticsearchStore,
     BM25RetrievalStrategy,
@@ -386,7 +386,6 @@ class TestVectorStore:
     async def test_max_marginal_relevance_search(
         self,
         hybrid_store: AsyncElasticsearchStore,
-        embeddings: Embeddings,
         static_hits: List[Dict],
     ) -> None:
         hybrid_store._store.max_marginal_relevance_search = AsyncMock(  # type: ignore[assignment]
@@ -400,7 +399,6 @@ class TestVectorStore:
         )
         assert actual == [Document("test")]
         hybrid_store._store.max_marginal_relevance_search.assert_awaited_with(
-            embedding_service=AsyncEmbeddingServiceAdapter(embeddings),
             query="qqq",
             query_embedding=None,
             vector_field="vector",
@@ -426,7 +424,6 @@ class TestVectorStore:
         )
         assert actual == [Document("test")]
         store._store.max_marginal_relevance_search.assert_awaited_with(
-            embedding_service=None,
             query=None,
             query_embedding=[1.0, 2.0, 3.0],
             vector_field="vector",

--- a/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_async/test_vectorstores.py
@@ -402,6 +402,33 @@ class TestVectorStore:
         hybrid_store._store.max_marginal_relevance_search.assert_awaited_with(
             embedding_service=AsyncEmbeddingServiceAdapter(embeddings),
             query="qqq",
+            query_embedding=None,
+            vector_field="vector",
+            k=8,
+            num_candidates=19,
+            lambda_mult=0.3,
+            fields=None,
+            custom_query=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_marginal_relevance_search_with_query_embedding(
+        self, store: AsyncElasticsearchStore, static_hits: List[Dict]
+    ) -> None:
+        store._store.max_marginal_relevance_search = AsyncMock(  # type: ignore[assignment]
+            return_value=static_hits
+        )
+        actual = await store.amax_marginal_relevance_search(
+            query_embedding=[1.0, 2.0, 3.0],
+            k=8,
+            fetch_k=19,
+            lambda_mult=0.3,
+        )
+        assert actual == [Document("test")]
+        store._store.max_marginal_relevance_search.assert_awaited_with(
+            embedding_service=None,
+            query=None,
+            query_embedding=[1.0, 2.0, 3.0],
             vector_field="vector",
             k=8,
             num_candidates=19,

--- a/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
@@ -438,6 +438,15 @@ class TestVectorStore:
         )
 
     @pytest.mark.sync
+    def test_max_marginal_relevance_search_requires_query_or_embedding(
+        self, store: ElasticsearchStore
+    ) -> None:
+        with pytest.raises(
+            ValueError, match="specify either query or query_embedding to search"
+        ):
+            store.max_marginal_relevance_search()
+
+    @pytest.mark.sync
     def test_elasticsearch_hybrid_scores_guard(
         self, hybrid_store: ElasticsearchStore
     ) -> None:

--- a/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
@@ -19,7 +19,7 @@ from langchain_elasticsearch._sync.vectorstores import (
     _convert_retrieval_strategy,
 )
 from langchain_elasticsearch._utilities import _hits_to_docs_scores
-from langchain_elasticsearch.embeddings import Embeddings, EmbeddingServiceAdapter
+from langchain_elasticsearch.embeddings import Embeddings
 from langchain_elasticsearch.vectorstores import (
     BM25RetrievalStrategy,
     DistanceMetric,
@@ -386,7 +386,6 @@ class TestVectorStore:
     def test_max_marginal_relevance_search(
         self,
         hybrid_store: ElasticsearchStore,
-        embeddings: Embeddings,
         static_hits: List[Dict],
     ) -> None:
         hybrid_store._store.max_marginal_relevance_search = Mock(  # type: ignore[assignment]
@@ -400,7 +399,6 @@ class TestVectorStore:
         )
         assert actual == [Document("test")]
         hybrid_store._store.max_marginal_relevance_search.assert_called_with(
-            embedding_service=EmbeddingServiceAdapter(embeddings),
             query="qqq",
             query_embedding=None,
             vector_field="vector",
@@ -426,7 +424,6 @@ class TestVectorStore:
         )
         assert actual == [Document("test")]
         store._store.max_marginal_relevance_search.assert_called_with(
-            embedding_service=None,
             query=None,
             query_embedding=[1.0, 2.0, 3.0],
             vector_field="vector",

--- a/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
+++ b/libs/elasticsearch/tests/unit_tests/_sync/test_vectorstores.py
@@ -402,6 +402,33 @@ class TestVectorStore:
         hybrid_store._store.max_marginal_relevance_search.assert_called_with(
             embedding_service=EmbeddingServiceAdapter(embeddings),
             query="qqq",
+            query_embedding=None,
+            vector_field="vector",
+            k=8,
+            num_candidates=19,
+            lambda_mult=0.3,
+            fields=None,
+            custom_query=None,
+        )
+
+    @pytest.mark.sync
+    def test_max_marginal_relevance_search_with_query_embedding(
+        self, store: ElasticsearchStore, static_hits: List[Dict]
+    ) -> None:
+        store._store.max_marginal_relevance_search = Mock(  # type: ignore[assignment]
+            return_value=static_hits
+        )
+        actual = store.max_marginal_relevance_search(
+            query_embedding=[1.0, 2.0, 3.0],
+            k=8,
+            fetch_k=19,
+            lambda_mult=0.3,
+        )
+        assert actual == [Document("test")]
+        store._store.max_marginal_relevance_search.assert_called_with(
+            embedding_service=None,
+            query=None,
+            query_embedding=[1.0, 2.0, 3.0],
             vector_field="vector",
             k=8,
             num_candidates=19,


### PR DESCRIPTION
Closes https://github.com/langchain-ai/langchain-elastic/issues/40

- Add query_embedding support to Elasticsearch MMR search 
- ~Keep langchain_core method signature compatibility by reading query_embedding from **kwargs.~
- Add async unit coverage for embedding-only MMR path and forwarding behavior.

