### PR TITLE
revert: elasticsearch client to <9.0.0 for ES 8 compatibility

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -69,11 +69,6 @@ jobs:
         shell: bash
         run: poetry install --with=test_integration,test
 
-      - name: Downgrade ES client for ES 8.x servers
-        if: startsWith(matrix.elasticsearch-version, '8.')
-        shell: bash
-        run: poetry run pip install 'elasticsearch[vectorstore_mmr]>=8.19.0,<9.0.0'
-
       - name: Run integration tests
         shell: bash
         run: make integration_test

--- a/libs/elasticsearch/pyproject.toml
+++ b/libs/elasticsearch/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 langchain-core = "^1.2.5"
-elasticsearch = {version = ">=8.19.0,<10.0.0", extras = ["vectorstore_mmr"]}
+elasticsearch = {version = ">=8.19.0,<9.0.0", extras = ["vectorstore_mmr"]}
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
## Summary
Partial revert of #109

- Pins `elasticsearch` client back to `>=8.19.0,<9.0.0` — the ES 9 client sends incompatible version headers that break ES 8 servers
- Removes the CI workaround step that was downgrading the client for ES 8 matrix entries (no longer needed with the pin)

## Test plan
- [x] CI integration tests pass against ES 8.15.0 and 8.19.0 matrix entries
- [x] Verify ES 8 users can install and use the package without version conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)